### PR TITLE
Fix secp256k1 build failure

### DIFF
--- a/VCCrypto/VcCrypto.podspec
+++ b/VCCrypto/VcCrypto.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |spec|
   spec.source_files  = "Classes", "Classes/**/*.{h,m}"
   spec.exclude_files = "Classes/Exclude"
   spec.framework  = "Foundation"
-  spec.dependency "bitcoin-core-secp256k1"
+  spec.dependency "secp256k1_ios"
 
 end

--- a/VCCrypto/VcCrypto/Algo/Secp256k1.swift
+++ b/VCCrypto/VcCrypto/Algo/Secp256k1.swift
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import Foundation
-import bitcoin_core_secp256k1
+import secp256k1_ios
 
 enum Secp256k1Error: Error {
     case invalidMessageHash

--- a/sdk/Podfile.lock
+++ b/sdk/Podfile.lock
@@ -1,5 +1,4 @@
 PODS:
-  - bitcoin-core-secp256k1 (0.1.6)
   - PromiseKit (6.8.0):
     - PromiseKit/CorePromise (= 6.8.0)
     - PromiseKit/Foundation (= 6.8.0)
@@ -9,21 +8,22 @@ PODS:
     - PromiseKit/CorePromise
   - PromiseKit/UIKit (6.8.0):
     - PromiseKit/CorePromise
+  - secp256k1_ios (0.1.3)
   - VcCrypto (0.0.1-beta.0):
-    - bitcoin-core-secp256k1
+    - secp256k1_ios
   - VcNetworking (0.0.1-beta.0):
     - PromiseKit (= 6.8)
 
 DEPENDENCIES:
-  - bitcoin-core-secp256k1
   - PromiseKit (= 6.8)
+  - secp256k1_ios
   - VcCrypto (from `../VcCrypto`)
   - VcNetworking (from `../VcNetworking`)
 
 SPEC REPOS:
   trunk:
-    - bitcoin-core-secp256k1
     - PromiseKit
+    - secp256k1_ios
 
 EXTERNAL SOURCES:
   VcCrypto:
@@ -32,11 +32,11 @@ EXTERNAL SOURCES:
     :path: "../VcNetworking"
 
 SPEC CHECKSUMS:
-  bitcoin-core-secp256k1: c2f87afc7f002cd84ae89b64d32e1ff4fa282f65
   PromiseKit: 02c93833283c37ce94ef7d25de63d48d62b0754e
-  VcCrypto: 2dabb8451c0dc3d549e7a326c2c3a11db6788de4
+  secp256k1_ios: ac9ef04e761f43c58012b28548afa91493761f17
+  VcCrypto: 2f6830953cfa2a5eab877f5671acf02dce031947
   VcNetworking: 7357df2c5af0160390e9456263f20ce0fdcabeda
 
 PODFILE CHECKSUM: 587700893476c873d7d0f9a81b2e112be366034a
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.3

--- a/sdk/Pods/Manifest.lock
+++ b/sdk/Pods/Manifest.lock
@@ -1,5 +1,4 @@
 PODS:
-  - bitcoin-core-secp256k1 (0.1.6)
   - PromiseKit (6.8.0):
     - PromiseKit/CorePromise (= 6.8.0)
     - PromiseKit/Foundation (= 6.8.0)
@@ -9,21 +8,22 @@ PODS:
     - PromiseKit/CorePromise
   - PromiseKit/UIKit (6.8.0):
     - PromiseKit/CorePromise
+  - secp256k1_ios (0.1.3)
   - VcCrypto (0.0.1-beta.0):
-    - bitcoin-core-secp256k1
+    - secp256k1_ios
   - VcNetworking (0.0.1-beta.0):
     - PromiseKit (= 6.8)
 
 DEPENDENCIES:
-  - bitcoin-core-secp256k1
   - PromiseKit (= 6.8)
+  - secp256k1_ios
   - VcCrypto (from `../VcCrypto`)
   - VcNetworking (from `../VcNetworking`)
 
 SPEC REPOS:
   trunk:
-    - bitcoin-core-secp256k1
     - PromiseKit
+    - secp256k1_ios
 
 EXTERNAL SOURCES:
   VcCrypto:
@@ -32,11 +32,11 @@ EXTERNAL SOURCES:
     :path: "../VcNetworking"
 
 SPEC CHECKSUMS:
-  bitcoin-core-secp256k1: c2f87afc7f002cd84ae89b64d32e1ff4fa282f65
   PromiseKit: 02c93833283c37ce94ef7d25de63d48d62b0754e
-  VcCrypto: 2dabb8451c0dc3d549e7a326c2c3a11db6788de4
+  secp256k1_ios: ac9ef04e761f43c58012b28548afa91493761f17
+  VcCrypto: 2f6830953cfa2a5eab877f5671acf02dce031947
   VcNetworking: 7357df2c5af0160390e9456263f20ce0fdcabeda
 
 PODFILE CHECKSUM: 587700893476c873d7d0f9a81b2e112be366034a
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.3

--- a/sdk/Pods/Pods.xcodeproj/project.pbxproj
+++ b/sdk/Pods/Pods.xcodeproj/project.pbxproj
@@ -9,564 +9,471 @@
 /* Begin PBXAggregateTarget section */
 		37DBAFDC20E13984CC335B195F5E85D9 /* VcNetworking */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = E08137701D42A2C81C217984B7CCABBD /* Build configuration list for PBXAggregateTarget "VcNetworking" */;
+			buildConfigurationList = 9487088F46F954A7C841634987900DF3 /* Build configuration list for PBXAggregateTarget "VcNetworking" */;
 			buildPhases = (
 			);
 			dependencies = (
-				92D1A94A3BEA8B3EC7386AAFB151CB66 /* PBXTargetDependency */,
+				6361D62647C5CD08886E63F303E0D509 /* PBXTargetDependency */,
 			);
 			name = VcNetworking;
 		};
 		9AE68C3D8E67C47FB2C8E83198549C5F /* VcCrypto */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = CAA64A672A550FF145510D88447DC586 /* Build configuration list for PBXAggregateTarget "VcCrypto" */;
+			buildConfigurationList = FCCA7B74C4EA671D22599261E597A2B0 /* Build configuration list for PBXAggregateTarget "VcCrypto" */;
 			buildPhases = (
 			);
 			dependencies = (
-				457FD41BF44624F76CA4B0875B50308A /* PBXTargetDependency */,
+				B72C50904DEB1A7797F7AF7067B3C2D5 /* PBXTargetDependency */,
 			);
 			name = VcCrypto;
 		};
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		0062DDC5C8321E8463CA7DC4A390B63A /* scalar_4x64.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CBA08A665295E2056C26FFEBDD34ADC /* scalar_4x64.h */; };
-		007813D215A0BE71E1E4D4126DBA8F1D /* NSTask+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 3237E0A6AFFEDEFA869A0B935911434A /* NSTask+AnyPromise.m */; };
-		04962D6927F0EBC7B36D70EFCB8341ED /* scalar_low.h in Headers */ = {isa = PBXBuildFile; fileRef = DE99681D72B645575A3B31F1878B6B3E /* scalar_low.h */; };
-		0C7FE14DF3D75AEA6BCDAEFDF6D16BE6 /* scalar_4x64_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 9F7E6155D9D0C1F05D36EF36221BEDAB /* scalar_4x64_impl.h */; };
-		0CC6F25BB8104721CC132F3A3492DE79 /* ecdsa.h in Headers */ = {isa = PBXBuildFile; fileRef = 57F77B70178D80BF5067756DE869B9A8 /* ecdsa.h */; };
-		0DC3A51FC74BDA5F1F6F0F787847AE46 /* firstly.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA31378D72B1854484A3AE24090C9E23 /* firstly.swift */; };
-		127CC05729CA6C49F23289CBD1B33A21 /* field_5x52_int128_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AB30D83F5947CFF59E69DFEE6520A2A /* field_5x52_int128_impl.h */; };
-		128123D41007EF2CEE6FEC4B6DDFABDF /* scalar_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 82755C006283793A77E1BD87508560F5 /* scalar_impl.h */; };
-		157D661897E4E0B694AE326167B925EE /* Guarantee.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35BC4349E1FD5846C567D70FCFF0AC4 /* Guarantee.swift */; };
-		167E4B1DDE01AB1072D449721EF3572E /* secp256k1.c in Sources */ = {isa = PBXBuildFile; fileRef = D62F2EFA7AB63909208572E68F4BB8E3 /* secp256k1.c */; settings = {COMPILER_FLAGS = "-Wno-shorten-64-to-32 -Wno-conditional-uninitialized -Wno-long-long -Wno-overlength-strings -Wno-unused-function"; }; };
-		170F2B353E8857CB25B560E5BC8D851C /* NSURLSession+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 19467827B2F45A595370C58513268EDB /* NSURLSession+AnyPromise.m */; };
-		173B398B33FF1967C97F1C97E2457BFF /* tests_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 04DE1D978C2B59117A5735206C047D69 /* tests_impl.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		17AAF2F787966C84BFAA95423D4D2DDF /* Pods-VcJwt-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BB8DECD5EB000E08B56619F628A2D96F /* Pods-VcJwt-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1CEDE74CCF37034825911D9E3D864D6A /* hash.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 75FD3CD25D90F4DD1F4FE54AF362269C /* hash.h */; };
-		1D3283CADAE5A7E49E6E563BAC4BEA26 /* AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FFFD33A919760ADE3176D92B725531C /* AnyPromise.m */; };
-		1EE6E859C9F803756B432B28FDE78DBB /* hash_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 59638B0B1B5532B717C69B560940EFDC /* hash_impl.h */; };
-		20EAD1D9035738A5FCE8DB1DC86992C6 /* CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC754938C9FB23E1FEF34D5F307D640 /* CustomStringConvertible.swift */; };
-		2277BCFF84E184ADBABCB2C218E1CE00 /* field_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = D47943C7EA6F97F2323EC971B75DEE8B /* field_impl.h */; };
-		237648C7A378710FBF60DD8FA89328F9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
-		26D210114481EAE30A5EB236900005CA /* Pods-VcCrypto-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = BFBCC8896FC7CC012C3622387DCDD9D4 /* Pods-VcCrypto-dummy.m */; };
-		27E6D7525C5508FF01EC9CBEF42E4509 /* hash_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 59638B0B1B5532B717C69B560940EFDC /* hash_impl.h */; };
-		29D55AD871DF1964ABD11AAF5E48BBC3 /* AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = AC39F1E8A5A681B26E9B512F3B2C90FB /* AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2A9A2ECFC5B9D43FD4754646294BDA2E /* scalar.h in Headers */ = {isa = PBXBuildFile; fileRef = 092C8A6D04604C2959105D64F9C965C9 /* scalar.h */; };
-		2B2F29CCC0E00B3CCADE66C7ECC19081 /* field_5x52.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 254036BDF02E8B5E0A0B3B8474AFF790 /* field_5x52.h */; };
-		2D0C7B87FF9F9275047C2C14FACC9E93 /* UIView+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80D7C75CDCD587F23CC29B3B1A72D21 /* UIView+Promise.swift */; };
-		2FF9F44E2B1557815134D2FD52694E4B /* scalar_8x32.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 50DDFDB314A42CE9CC5746DF0AC0D1E5 /* scalar_8x32.h */; };
-		3013FBBA8D4A9BCE7568AF4DFF39812F /* field_5x52_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 4CA73410BAD385AFACD9732A9996859E /* field_5x52_impl.h */; };
-		301A2994622F71810829C83C3B5C6E63 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
-		309134D31427D8A84B55D93F03104C93 /* dispatch_promise.m in Sources */ = {isa = PBXBuildFile; fileRef = 522C3CAACE0477E91BB6A3A9D9E9F663 /* dispatch_promise.m */; };
-		30BCA1FE6C490D5BAB5105BFEB8C6CC0 /* Pods-VcNetworking-VcNetworkingTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DA35576EF1835E96B3BAAF86A6863E83 /* Pods-VcNetworking-VcNetworkingTests-dummy.m */; };
-		30ECF1F8A95BF3A742F9F8FBD0151BF0 /* ecmult_const.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = FBA66929FE4491B4DC0CF67A2ADAC42E /* ecmult_const.h */; };
-		34DE10A8B540221FEB0069F92503A3CC /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBF5A6FC4E52452C68782CE2F701BA4D /* Error.swift */; };
-		36DF15BDC7973AFCF4B2C4560DF684F2 /* Pods-VcJwt-VcJwtTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F74A67686579616885C47FBDEE16D7D /* Pods-VcJwt-VcJwtTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3A8A39A2CC51F46073A638BF0D3CFA8A /* eckey.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = F4BD4022F180C944F0C037A0C4C719A3 /* eckey.h */; };
-		3BA19753292E7D3672BCD0ECB28AF69C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
-		3BB3B3EDD1071473F621506B75B57E86 /* group_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 4D555BB7F954235881771E11B587CF7D /* group_impl.h */; };
-		3E1B08E5A2C1E58384F075C8F653537C /* bitcoin-core-secp256k1-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A74FF48648B65F4D615783FBB96091AA /* bitcoin-core-secp256k1-dummy.m */; };
-		3EF0598F35C4D88F4CEC7DD8A250BAEB /* race.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B2B261C3EEEC9F92C5464CD0FAAA13 /* race.m */; };
-		3F7B9490387407CEFDC4306E87039BFA /* field_5x52_asm_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 6555C520A49FE51A6FBCB72A7E4E0644 /* field_5x52_asm_impl.h */; };
-		40453F3F1904D3880F1D9F5865614375 /* ecmult.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 5F9948ADFF702D01AEECEFAF7656A276 /* ecmult.h */; };
-		44E9EDDEEA8C5B9712048F9D065B6C4C /* ecmult_const_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 938B36D96A3F24AA449046C0753CAD45 /* ecmult_const_impl.h */; };
-		47C54EFB16CC84D2D9EC24AFF465E521 /* Pods-VcCrypto-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A5FABFD3DF1528E7F959C40B23727338 /* Pods-VcCrypto-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		49325C685ACD95BB2A71E4FA951A87F5 /* ecmult_gen.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 1C04FB4E47DE959155FC5E512E26D630 /* ecmult_gen.h */; };
-		495E6F821F16C52B42444B79176B3093 /* secp256k1_preallocated.h in Copy include Public Headers */ = {isa = PBXBuildFile; fileRef = D4C549A9D2D3EADF98D88710605C195C /* secp256k1_preallocated.h */; };
+		007813D215A0BE71E1E4D4126DBA8F1D /* NSTask+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = C0CC4441F818499CA22F18AF8BEBA978 /* NSTask+AnyPromise.m */; };
+		04D0046311C21A01BA8B8D048EDCFE95 /* Pods-sdk-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B7F2AA41A756CDA0AC92E8408C038C42 /* Pods-sdk-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0845026EB21CF5C376D9EF76A06E733E /* group_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 174ED2AFD0A4B7DD241777987932DDD5 /* group_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0847F7F254A89E19126A52D24FBC5CA2 /* num_gmp.h in Headers */ = {isa = PBXBuildFile; fileRef = C865F5F867FCB991FC50CA9687D105F2 /* num_gmp.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0ACE05FCD4954CD9EF618CE4046E280F /* secp256k1.h in Headers */ = {isa = PBXBuildFile; fileRef = 42183EE1C6E2CBE0704C8213F9D97712 /* secp256k1.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0DC3A51FC74BDA5F1F6F0F787847AE46 /* firstly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97DE9991CD4766CCF7DFD839AC848D4B /* firstly.swift */; };
+		0FB197AB0C07D678DA85A5748D7A89DE /* Pods-VcNetworking-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B86999909745D8DAC7F3CBF6A9395EE7 /* Pods-VcNetworking-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		114144939176AEB7EC8F53385679FA5C /* secp256k1_ios.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A29BF806D25C7FB68DA035F723BCE26 /* secp256k1_ios.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		157D661897E4E0B694AE326167B925EE /* Guarantee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EA20861088FACDC61C8C51E1FAF700 /* Guarantee.swift */; };
+		170F2B353E8857CB25B560E5BC8D851C /* NSURLSession+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = A02ACE07DAF9653C72C85571C867DAF5 /* NSURLSession+AnyPromise.m */; };
+		17E1BABDD636ECB46EACCF1D2E968663 /* ecmult_const.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B214A3CA7FE949A02513F6722C0C2D0 /* ecmult_const.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		197403401F865B195517322CD447D412 /* Pods-VcJwt-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CA5338110A0860CDDD771C68CED55767 /* Pods-VcJwt-dummy.m */; };
+		1D3283CADAE5A7E49E6E563BAC4BEA26 /* AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C3960246814482A3687E5F19E64CE5 /* AnyPromise.m */; };
+		20EAD1D9035738A5FCE8DB1DC86992C6 /* CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB01212F7A6B19DC6A3E26AFC4ACF2C /* CustomStringConvertible.swift */; };
+		29D55AD871DF1964ABD11AAF5E48BBC3 /* AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 5ED21860AAC5C75752EBA9698A6DED74 /* AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A1693A6903F4222FE5AE3EFE0E545EB /* field.h in Headers */ = {isa = PBXBuildFile; fileRef = AA70392775FC09CA0A5566C942B2D5D7 /* field.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2D0C7B87FF9F9275047C2C14FACC9E93 /* UIView+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0FE94A2A17EC2649755A1A87228694 /* UIView+Promise.swift */; };
+		2DC7815A7622771B86E4CBC2D072E790 /* secp256k1_ecdh.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BB7072EC80533A9DB4161D418152882 /* secp256k1_ecdh.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2E35C2C7D151A14B1A25D04DBCB6519A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
+		309134D31427D8A84B55D93F03104C93 /* dispatch_promise.m in Sources */ = {isa = PBXBuildFile; fileRef = A2EA213B48DC28B4037837BDC7410D0C /* dispatch_promise.m */; };
+		32F4BD576FE7040B473AE1E3D3D8346A /* scalar_low_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = FFDD3C629AC54926AD39A2158000BCFD /* scalar_low_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		34DE10A8B540221FEB0069F92503A3CC /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06C3BAEBD327280F000B6BEE407EB681 /* Error.swift */; };
+		3B1458841AD8CD6BCB2BFFF82FC0FBE3 /* secp256k1_ios-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DE6FA170EC3BDE6DB448239C1942BD6C /* secp256k1_ios-dummy.m */; };
+		3C824938EF654C5F5E455E891CBBC99E /* Pods-VcJwt-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BB8DECD5EB000E08B56619F628A2D96F /* Pods-VcJwt-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3EF0598F35C4D88F4CEC7DD8A250BAEB /* race.m in Sources */ = {isa = PBXBuildFile; fileRef = 3500F51E4117B09F15D007270B88AE4A /* race.m */; };
+		3F56139E64FD0396BF78AF881DDDD7D1 /* scalar_4x64_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 73DA0DBD3D421C8A8A93C2F517ED6B48 /* scalar_4x64_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3F6A7BDD385B44952FFB8AB61EE7BB82 /* field_10x26_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 23DE15C88C33ED4A73994B094C2643E3 /* field_10x26_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3FC467587AAFD0ADA9DC26B03101D221 /* field_10x26.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C8A62387E870EA43D03CA53DCEE0C1D /* field_10x26.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		417C05FB4C3B1DBD1D84BB76D21ADA07 /* field_5x52_int128_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = F00A8F673B90C211CDFBFDF738DFBF27 /* field_5x52_int128_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		439E8938301084A4BDF09CFEC5D4BC6A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
+		4507D6A4F46570721A12B3C062825DCC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
 		4A613C22671DE0E90BC4F1B70CB3B479 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
-		4CE92A0F3E2AB2BD3CB7CC6389A83FC7 /* field_10x26.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = E9620E1C596E2E47F3B680F788369306 /* field_10x26.h */; };
-		513C5C141F115DB01F9C5877EACC498D /* ecmult_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D78F27BB75E50CD2FD6188C55E27373 /* ecmult_impl.h */; };
-		5175A9213A70AAAC436BED04833C7F57 /* ecmult_gen.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C04FB4E47DE959155FC5E512E26D630 /* ecmult_gen.h */; };
-		5218E23F7F9BD828D2370E15EA536B9C /* scalar_low_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 766F71A777BA671115D8917E39170A1C /* scalar_low_impl.h */; };
-		5243E5D2DA9468B680129F9299F72207 /* Pods-sdk-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 24EB90B5CFEE83BC4C39D3C8DC878479 /* Pods-sdk-dummy.m */; };
-		54806BFF8A94540CA146BCD4337C081C /* num_gmp.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 7CB299F3A6210695F1FD309BAA9AEF75 /* num_gmp.h */; };
-		5553F16DA39F70B1B6EF4CD0B388F066 /* secp256k1.h in Headers */ = {isa = PBXBuildFile; fileRef = 11072080A5FE47752615651BC0F878CB /* secp256k1.h */; };
+		4A9B8EEB1D3196184111055D37614E1F /* Pods-VcJwt-VcJwtTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C21771D239B20B2491846F2B5ABC63 /* Pods-VcJwt-VcJwtTests-dummy.m */; };
+		4CF8B1A3715F54EC0194098636CBEBAD /* eckey_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = BFDAFDA15AC40DE93C97A4D5D27D7A74 /* eckey_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		54E27E1C5982BE6F6B74DE723F554100 /* scalar_low.h in Headers */ = {isa = PBXBuildFile; fileRef = A687BD5D47AAA0C72FE790A90D841E5D /* scalar_low.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		563FD527C414D9E30F685148B632C828 /* num_gmp_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A4B21AB340724F56E2462F8F700278F /* num_gmp_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		56D8783CBF33646ECBF610FCC8EFC43E /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 312B988EF117AE4DE76A268D970131FE /* UIKit.framework */; };
-		582A9D494D23B1C551310B36AE120ACE /* hang.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE9610DD10C3F32371E4BD06B2F25A5 /* hang.swift */; };
-		590206EDC2307E8C2168320D0003C59A /* tests_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BFEBCBBC1EDAFBB554B2FCCFBF5B5D0 /* tests_impl.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		5969807D0767490C7FAF57E73E433D3B /* field_10x26.h in Headers */ = {isa = PBXBuildFile; fileRef = E9620E1C596E2E47F3B680F788369306 /* field_10x26.h */; };
-		5DB57F3E97DE90045FD326E65DD7A45E /* fwd.h in Headers */ = {isa = PBXBuildFile; fileRef = 4315C0CC711137AAEB92AFEA7D43D25A /* fwd.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5E2625911BE3874644F79C98334AA8AE /* afterlife.swift in Sources */ = {isa = PBXBuildFile; fileRef = E586CD62595B6116F796EC6D4087F32F /* afterlife.swift */; };
-		5E393762CF5329505675EEE724090F06 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49BCF208D11EE478A05AAF9800A7E31 /* Deprecations.swift */; };
-		5E72C91F7BB69C8984571EEE4824CA56 /* scratch.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = C61EEAA77AC36DB5F3679E2891202A98 /* scratch.h */; };
-		605D8FABF466627ABDAD7388EBE669E8 /* scratch_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 2FADC424BE7BF6C4154E9EEC1C2D6B37 /* scratch_impl.h */; };
-		60D0C409BB446141FC99D1CD5D5D445C /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220DA8A861A195B90F9F7D54C61E3B56 /* Configuration.swift */; };
-		615CDF6B72AF227417A0952CEEDC3848 /* field_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = D47943C7EA6F97F2323EC971B75DEE8B /* field_impl.h */; };
-		61C0CED9E188678C919F058C64CBE917 /* bitcoin-core-secp256k1-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1769986EB7E8D241D2DD7CC4E6521A67 /* bitcoin-core-secp256k1-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6468A5C13CF2D853BA8D699574D5FF44 /* field_10x26_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = B6A9E8F5AA16BDB7CA095B0B132DF844 /* field_10x26_impl.h */; };
-		66D51CFAD06894D21D81875E392F9F9C /* scalar_8x32_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 29C74ECC00EE31C2D221E471208650E3 /* scalar_8x32_impl.h */; };
-		67135B603F808E68183713E5765DD1F1 /* scalar_4x64_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F7E6155D9D0C1F05D36EF36221BEDAB /* scalar_4x64_impl.h */; };
-		6742741733D04305CB5610A06FD35278 /* when.m in Sources */ = {isa = PBXBuildFile; fileRef = B8CDE7E03F7FFBAB8AEF76950B03A3DB /* when.m */; };
-		6A074E2F079D738F3D8237BB2DA665FA /* ecmult_const.h in Headers */ = {isa = PBXBuildFile; fileRef = FBA66929FE4491B4DC0CF67A2ADAC42E /* ecmult_const.h */; };
-		6D8BA89C98C379ECED581370EBE1CD92 /* ecdsa_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = F5D86CAF969ABF249E5F44E80F70D6FC /* ecdsa_impl.h */; };
-		6E59D57B4AF73D833E81E8D380B6285D /* secp256k1_recovery.h in Headers */ = {isa = PBXBuildFile; fileRef = 9118411113C8AC271ADBD729F3A08037 /* secp256k1_recovery.h */; };
-		70FD9DF9CE7DEF7EC6818EF9703B8CCC /* scalar_4x64.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 4CBA08A665295E2056C26FFEBDD34ADC /* scalar_4x64.h */; };
-		7312821F81430D0DDA5DE998A95E8282 /* field_5x52.h in Headers */ = {isa = PBXBuildFile; fileRef = 254036BDF02E8B5E0A0B3B8474AFF790 /* field_5x52.h */; };
-		7508741780658CF1086F3B3F7AC3D57A /* NSURLSession+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E073F32B53B1BF948756FC0C654B624 /* NSURLSession+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		76E2BBA6504D4EC8CB21FBC9F02969CA /* PromiseKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B28B2A2E81B13D1C160294EBE8DA74D /* PromiseKit-dummy.m */; };
-		799323431ABB06FFAFD8C5ED23161212 /* num_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = EAF1187BC13645A12EACBF172AAA963B /* num_impl.h */; };
-		7A31D823DFAE2E054E30AAE454B98432 /* ecdsa.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 57F77B70178D80BF5067756DE869B9A8 /* ecdsa.h */; };
-		7BCDE06FCA0E5D3ECC1CD83695A9F1C6 /* field_5x52_asm_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 6555C520A49FE51A6FBCB72A7E4E0644 /* field_5x52_asm_impl.h */; };
-		7CD5B6F4F5CF8C28D698E81E0B080878 /* ecmult.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F9948ADFF702D01AEECEFAF7656A276 /* ecmult.h */; };
-		7CEE635BA2464A2A20B2B4F84FB6C6B1 /* group.h in Headers */ = {isa = PBXBuildFile; fileRef = A3FBB9478AAA18A15E7DBABBCEBC01FD /* group.h */; };
-		8022C0FF236CB784CE80560C2543DF24 /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C6B94622B196AE1DE59D3276DE73D5 /* Resolver.swift */; };
-		8215B8CC79A345D254F6388D9348C3A1 /* secp256k1_ecdh.h in Copy include Public Headers */ = {isa = PBXBuildFile; fileRef = BC57494B77FCC93ACACB308CF9E3631C /* secp256k1_ecdh.h */; };
-		82D5C0A1EB64670CE46081210A41AD8B /* UIView+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = E76431A8C01E16FB984BC641B1482EAA /* UIView+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8445B7D9F0377EF82100C01871C8D9E2 /* Thenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC04EF6E845E7832336EF1B12AC9E04 /* Thenable.swift */; };
-		869FFDEE205BAD4838606AFC0E24DD67 /* field.h in Headers */ = {isa = PBXBuildFile; fileRef = EEC3F3EDA395D7520424BD541862AA16 /* field.h */; };
-		8831B4426EE40154CFDBD55D26166C0E /* UIViewController+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1B990AF95F4DBE8672AC21882386C3 /* UIViewController+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A52D90A0E37D2772C8D19261148EC3B /* ecmult_gen_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 21E61B955C6DCF3B115F398121FF0A43 /* ecmult_gen_impl.h */; };
-		8AFF8E5B1323A6458FE2E55D280EE963 /* Pods-VcNetworking-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B86999909745D8DAC7F3CBF6A9395EE7 /* Pods-VcNetworking-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8BD443A42C5C718BC8843BBC83254152 /* Pods-VcNetworking-VcNetworkingTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 95ADB8E4CAD8828B1BF6FB48F33CF488 /* Pods-VcNetworking-VcNetworkingTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8C15DCDFD43578EDA5EF25BDAC664ED6 /* ecdsa_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = F5D86CAF969ABF249E5F44E80F70D6FC /* ecdsa_impl.h */; };
-		8EF64DB263F87A20BFBF819CF387A513 /* field_10x26_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = B6A9E8F5AA16BDB7CA095B0B132DF844 /* field_10x26_impl.h */; };
-		8F3C62F12DCDBCC079618CCBA54542F8 /* eckey.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BD4022F180C944F0C037A0C4C719A3 /* eckey.h */; };
-		8FDE0012D19F7BE581A08A1C60F56070 /* LogEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12DC8F7031D40A0A47C4F18F42315CAC /* LogEvent.swift */; };
-		902AF9717AB07CE7D8C982D0E603A68C /* ecmult_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 4D78F27BB75E50CD2FD6188C55E27373 /* ecmult_impl.h */; };
-		9359B5BEDE0F9A1C0CDE4B8B2DFC8C4D /* scratch.h in Headers */ = {isa = PBXBuildFile; fileRef = C61EEAA77AC36DB5F3679E2891202A98 /* scratch.h */; };
-		93E32E0840F99DE79421E31E8B886E6E /* main_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = F67418A4C5BB88BB468E0B60C5FA963E /* main_impl.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		94467C87C474A8D41C309A5133A8B675 /* UIViewPropertyAnimator+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E76143A41D6054F67BAD6B914A4788 /* UIViewPropertyAnimator+Promise.swift */; };
-		94C4DC0D39AE3F670ED2C15B9F34807E /* Pods-VcCrypto-VcCryptoTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = DC1A8979053D9CEF9AC5A00E418B4BCA /* Pods-VcCrypto-VcCryptoTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9699808CCF1174CD4D51ACCB3A3F6988 /* num_gmp_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 8AA69F9C9527192D189D7D5780F7C574 /* num_gmp_impl.h */; };
-		9AF1CB9B6F8E5EBE5420B396EC003604 /* util.h in Headers */ = {isa = PBXBuildFile; fileRef = 2817BCFFD9EBF0A304905121E1824141 /* util.h */; };
-		9C83E564AADD9C1F621FAC19DE07F912 /* num_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = EAF1187BC13645A12EACBF172AAA963B /* num_impl.h */; };
-		9E7F1714C21BB42C01032F4E2BF98F61 /* secp256k1_recovery.h in Copy include Public Headers */ = {isa = PBXBuildFile; fileRef = 9118411113C8AC271ADBD729F3A08037 /* secp256k1_recovery.h */; };
-		9EC14E8CEDF7D656021576C555B4BE95 /* scalar_8x32.h in Headers */ = {isa = PBXBuildFile; fileRef = 50DDFDB314A42CE9CC5746DF0AC0D1E5 /* scalar_8x32.h */; };
-		9F38F14D55B31C69D46E9F36C663AE3F /* basic-config.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 1AB72A6669EFC71F29FFE5B951A85B64 /* basic-config.h */; };
-		9F60C4BD58F2FB9F024EDD5281727456 /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = F673C693801031932449D23955759008 /* after.swift */; };
-		9FD195E2521B0D49C1E8DF74D047383C /* num.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 8B494C053D2E4BB1066CA1D24EB1AD6D /* num.h */; };
-		A2CB7D43B0511320372716A44086E9ED /* Pods-VcJwt-VcJwtTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C21771D239B20B2491846F2B5ABC63 /* Pods-VcJwt-VcJwtTests-dummy.m */; };
-		A3CBE98339DBAF5901D864620063C79F /* Pods-sdk-sdkTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1145C86F40C2887868145ED75A33CFE2 /* Pods-sdk-sdkTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A3DF146CF00ABFBEEEB93CA8C98E4A0F /* group.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = A3FBB9478AAA18A15E7DBABBCEBC01FD /* group.h */; };
-		A3E609FDE0A65BEB8FCD6C2CA37B59CA /* num_gmp_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AA69F9C9527192D189D7D5780F7C574 /* num_gmp_impl.h */; };
-		A6984C97150DC9D8A271FBCBBC1DCA54 /* race.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04597055A1A7A7F198D489FFEA7C893 /* race.swift */; };
-		A764BF9C3A45EC887EFD0EAB01E935CC /* NSObject+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26A56E3B8F06F12A9276D5074A5B4A7 /* NSObject+Promise.swift */; };
-		A81C8D7C62F3454A61F7ADCC89C96990 /* AnyPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F6E5B27BB5CB6B4D2846DDF1A5F3CC /* AnyPromise.swift */; };
-		A9CE6C7080FBCD19569BF940188C2F39 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
-		AA80180AEE71E25004BB4B17EDEDD464 /* ecmult_gen_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 21E61B955C6DCF3B115F398121FF0A43 /* ecmult_gen_impl.h */; };
-		AB5AE7BB2DA97A9E849725A2413F33DA /* field_5x52_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CA73410BAD385AFACD9732A9996859E /* field_5x52_impl.h */; };
-		AC189AB1FE874B42B98EDF41A8AC974E /* eckey_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 3CDA2CD70FF5E2272DA0F95B8EE4EEDB /* eckey_impl.h */; };
-		ADA3CD6798264852BCE51FA3CF137E52 /* eckey_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CDA2CD70FF5E2272DA0F95B8EE4EEDB /* eckey_impl.h */; };
-		AE8A2FF70E1FF19F05385C9465FBA051 /* field_5x52_int128_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 0AB30D83F5947CFF59E69DFEE6520A2A /* field_5x52_int128_impl.h */; };
-		AF4C0BBFF32F4BF0F0B83771115FCFDA /* Pods-sdk-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B7F2AA41A756CDA0AC92E8408C038C42 /* Pods-sdk-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B19B894D15BBB62C233BA2E09294369B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
-		B1DF3554388CDFBE4050CE9D3FC4C616 /* num.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B494C053D2E4BB1066CA1D24EB1AD6D /* num.h */; };
-		B6466FD0ABC0E5E98497B6384B063401 /* hang.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A7EF5955F461D82227208AFCEDECA69 /* hang.m */; };
-		B6FD9430FB9CCFE50E93DE797E519FCC /* UIViewController+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 36F921352F9288D40551163CBCE6FA1E /* UIViewController+AnyPromise.m */; };
-		BB1E618B1BD4B77570BBFCDE02F11F8E /* assumptions.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = FFDB7DCF590CA80CF4976FF708447B59 /* assumptions.h */; };
-		BFD73D585DF049387B8818B7833016EC /* Pods-VcNetworking-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F37EDB0E21047DD31A051CC54A1C2E28 /* Pods-VcNetworking-dummy.m */; };
-		C47AE531A5D2A2399277ED4320A5D11F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
-		C791131C5098B85172F7B1B7BB1C9CF2 /* secp256k1_ecdh.h in Headers */ = {isa = PBXBuildFile; fileRef = BC57494B77FCC93ACACB308CF9E3631C /* secp256k1_ecdh.h */; };
-		CAD4996BF8ECBA77CD4F1AFA07EAE46B /* Pods-VcCrypto-VcCryptoTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A0A196DDAC0BB85EE15E8319C4D3379 /* Pods-VcCrypto-VcCryptoTests-dummy.m */; };
-		CBE0628C41374467DAD7D28C6BB0DECE /* Catchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D170FB93A9659AC62EB96EEFBD07F89A /* Catchable.swift */; };
-		CC109599EB717FB4B908412C26F16850 /* Pods-VcJwt-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CA5338110A0860CDDD771C68CED55767 /* Pods-VcJwt-dummy.m */; };
-		CD94BBCACE341F873B1D51C641736C0F /* scalar.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 092C8A6D04604C2959105D64F9C965C9 /* scalar.h */; };
-		CDD6E93A8AC6AAF9B5B601C91FCD9ABA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
-		CE6F1D94FE37E625ECB61BB9980BF5F6 /* scalar_8x32_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 29C74ECC00EE31C2D221E471208650E3 /* scalar_8x32_impl.h */; };
-		CEF1FFB8DC404FF933102526A708A297 /* ecmult_const_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 938B36D96A3F24AA449046C0753CAD45 /* ecmult_const_impl.h */; };
-		D04A7984E0B5A3A092F6DD2FB4B6EA26 /* join.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F3593DF8DEA8D63547441DC7AC2A080 /* join.m */; };
-		D63DEBA99E5A3FA2A9A816EBECB31D1B /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABBA28790FD69DCD34B262FA4794D03E /* Box.swift */; };
-		DCB42ABED700C2118F77F8FDCF5F70B3 /* secp256k1_preallocated.h in Headers */ = {isa = PBXBuildFile; fileRef = D4C549A9D2D3EADF98D88710605C195C /* secp256k1_preallocated.h */; };
-		DD0DCDDF37A406834613483F10DE8296 /* UIView+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = E71384D1B500AB043FF90A3C77E5501A /* UIView+AnyPromise.m */; };
-		DF8EAD4722AC498D0E239DFBF83A7B68 /* basic-config.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AB72A6669EFC71F29FFE5B951A85B64 /* basic-config.h */; };
-		E14E81F881B656B09A1B3B2D00475E01 /* assumptions.h in Headers */ = {isa = PBXBuildFile; fileRef = FFDB7DCF590CA80CF4976FF708447B59 /* assumptions.h */; };
-		E1E9D3520BD28ED3C564D9BC5B890D57 /* main_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = A02DE9E74DEB9A256A9F457666C21E46 /* main_impl.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		E4B39D3E52F5024EDD04C4BC5A19735E /* Pods-sdk-sdkTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 196F6FCE438FF2073C21110387EABEE1 /* Pods-sdk-sdkTests-dummy.m */; };
-		E813DB8CC70E6123A7C7FBAE0E504B81 /* PMKFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD960E5387CEF78BCE09BD9B0D7E080 /* PMKFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E88FEC7862E707146C09810A14DFC44C /* scalar_low_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 766F71A777BA671115D8917E39170A1C /* scalar_low_impl.h */; };
-		E8A0C6676AFC75F7CF236D5CC7F74BB0 /* PMKUIKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 98D8EAE390CEF961B0370289A947A522 /* PMKUIKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E9115666403292A31A2B75BBB9D12C26 /* scalar_impl.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 82755C006283793A77E1BD87508560F5 /* scalar_impl.h */; };
-		E9AB9896FCF00E661FF0FDD11716487C /* NSURLSession+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD4500D2B1C260833A564AA518A3283 /* NSURLSession+Promise.swift */; };
-		EA71BE3EA1C0FCBF64CCE199F79DC03D /* group_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D555BB7F954235881771E11B587CF7D /* group_impl.h */; };
-		EBD2442574C3F059F2F2AAA86CF088B2 /* secp256k1.h in Copy include Public Headers */ = {isa = PBXBuildFile; fileRef = 11072080A5FE47752615651BC0F878CB /* secp256k1.h */; };
-		EBE4BD3D7C8F8F00CAF808438B23A1A0 /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00AA9B85AE0296B38EE49F201668070 /* Promise.swift */; };
-		EC4A2AF0DE9B68764ECAD72D0F3C5EAB /* after.m in Sources */ = {isa = PBXBuildFile; fileRef = 905C59B04706BE9C024D4C97CC37616D /* after.m */; };
-		ED79F258409E99BB8CB18994697BAFEF /* scalar_low.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = DE99681D72B645575A3B31F1878B6B3E /* scalar_low.h */; };
-		EDFF7078C59974F7BB1DF334AC7C47D8 /* NSNotificationCenter+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = E5C06A45625F17E4E194C69314E4A145 /* NSNotificationCenter+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EF28F9227CA6F4ACE4C7618C881DF70D /* hash.h in Headers */ = {isa = PBXBuildFile; fileRef = 75FD3CD25D90F4DD1F4FE54AF362269C /* hash.h */; };
-		EF3A12CAD983F86CD5CBFA744B2612A6 /* when.swift in Sources */ = {isa = PBXBuildFile; fileRef = 360908940B4F77BADE3771D2B9439229 /* when.swift */; };
-		EF6DA14F252481AD22FADAF253829E29 /* PromiseKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CC0E54668B48A9784A91C016F12FED0 /* PromiseKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F11A4AB7236A85C47FA9B33B00A224D4 /* Process+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CA7A569C295010860D536FCC3324BF /* Process+Promise.swift */; };
-		F2750E1A31C27E20517AF6016EA3FE8B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
-		F2C74E8681F4343C2036885563F88E9C /* scratch_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FADC424BE7BF6C4154E9EEC1C2D6B37 /* scratch_impl.h */; };
-		F3130E6206ACC486720380339D54E1EA /* PromiseKit.h in Headers */ = {isa = PBXBuildFile; fileRef = A35A5A64A2BA545E671773BE11179C05 /* PromiseKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F413DC82A060E79EC20CED3E9994CCC6 /* NSNotificationCenter+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99BF2586AEB072F8DB1E6B6BDDF8F4C /* NSNotificationCenter+Promise.swift */; };
-		F425B8776B8206D5DC57D6A8B70BCD58 /* field.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = EEC3F3EDA395D7520424BD541862AA16 /* field.h */; };
-		F4A258988E782EE7CF2B810E54C12F3D /* num_gmp.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CB299F3A6210695F1FD309BAA9AEF75 /* num_gmp.h */; };
-		F64C538EDB0C6BB9EAFA17BF98D8BA99 /* util.h in Copy src Private Headers */ = {isa = PBXBuildFile; fileRef = 2817BCFFD9EBF0A304905121E1824141 /* util.h */; };
-		FB93092887EF773B16F5E4544ADA4E2B /* NSTask+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C63CCB86A6BC83026C7E55E16E2B45E /* NSTask+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FCD66010C23D87F9B0E1EF2A7270A3BB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
-		FD7DF70E33BAB15E17DF298C74CD6FAC /* NSNotificationCenter+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 1848FB9DB0AE45FF4D680907B0E98523 /* NSNotificationCenter+AnyPromise.m */; };
+		582A9D494D23B1C551310B36AE120ACE /* hang.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CB2ADA690E2910241611766C32E2F3 /* hang.swift */; };
+		5D4CEF2F417A8E04098FE31934C51794 /* field_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = E524558EF7B0FA2C58EDD5F2A6B8ACF5 /* field_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5DB57F3E97DE90045FD326E65DD7A45E /* fwd.h in Headers */ = {isa = PBXBuildFile; fileRef = 8536E2C3428FEC0CBC83BA96D7B1F178 /* fwd.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5E2625911BE3874644F79C98334AA8AE /* afterlife.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEE0F74E0C9294EB8B6D4566B5914C /* afterlife.swift */; };
+		5E393762CF5329505675EEE724090F06 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BE938727019BB721FCF3A08FBD11E3C /* Deprecations.swift */; };
+		5F855A539D5FBD16A06C124B87825957 /* Pods-VcCrypto-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = BFBCC8896FC7CC012C3622387DCDD9D4 /* Pods-VcCrypto-dummy.m */; };
+		5FBA639EDCA4082B4DB5FF125C5E680B /* hash.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B20DE0D50C31BFF7CD0CC638E73A030 /* hash.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		60317F9BD96CF2B27323A8BCAAB53A1A /* secp256k1_ios-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 73AACAB60C21E8887475CF5FF0D76C5E /* secp256k1_ios-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		60D0C409BB446141FC99D1CD5D5D445C /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E61770C0AF5A531C4B9A50F318CFEB /* Configuration.swift */; };
+		6481564A095352F8F5933E69BC7C5C48 /* secp256k1_recovery.h in Headers */ = {isa = PBXBuildFile; fileRef = 10711BE548AED40F4C2EE0422167D557 /* secp256k1_recovery.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		65B07BACFDF68A6461EC8D3A7AB3AD3B /* lax_der_parsing.h in Headers */ = {isa = PBXBuildFile; fileRef = FC4E9889F9E1F402C3DB2B3A90676C11 /* lax_der_parsing.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6742741733D04305CB5610A06FD35278 /* when.m in Sources */ = {isa = PBXBuildFile; fileRef = 90F2E32C2C79B160376BBBA102BC4931 /* when.m */; };
+		67C06653732CA876A501061CB645082E /* group.h in Headers */ = {isa = PBXBuildFile; fileRef = E73D5A57C8F50B074932D85A899DCD0C /* group.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6CA3BCD7F8A8F4F945E467F641AB433E /* libsecp256k1-config.h in Headers */ = {isa = PBXBuildFile; fileRef = 69CF1B9477AEE675CD98E6C7931DCC15 /* libsecp256k1-config.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7276295CFCB4D103FC4EAD2373F52EA4 /* scalar_8x32.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B8AA9E8AFD6D1E00286A07C4AB350D8 /* scalar_8x32.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7423BDF21D71F98D9733CEE09EB0BD57 /* field_5x52_asm_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 05EE3D1F1EAAB7A8F7D94CFDDCB73990 /* field_5x52_asm_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7508741780658CF1086F3B3F7AC3D57A /* NSURLSession+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 51CC579DCE56A91B90B9E605836D243A /* NSURLSession+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		76E2BBA6504D4EC8CB21FBC9F02969CA /* PromiseKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 786D51C7D2122FE69C614EC855704160 /* PromiseKit-dummy.m */; };
+		76ECB04E1EAD266567EFF5ED8269E991 /* ecmult_gen_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 329A591E9BEEE33DE0B2644FBBAB3ED0 /* ecmult_gen_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7C48EB94DC67F324F6B94CA5E597AA8F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
+		7CB206B4966420E9AABD313CBD8AEAC7 /* secp256k1.c in Sources */ = {isa = PBXBuildFile; fileRef = E4321D605DC983B72C2F14B9F58BA5E8 /* secp256k1.c */; };
+		7E656DC2F28CC3B4A95563A61832356A /* main_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = B9F2029FCF6C147890BBFA918230D1D3 /* main_impl.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		7E91AAB4DD22F6D1623C458D27E430D2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
+		8022C0FF236CB784CE80560C2543DF24 /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480FC1D442C11B3F90011531FD2A997E /* Resolver.swift */; };
+		80C9CDA192D4A4B9A2811AA9C1C37CD8 /* util.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A1767B5AD12E1BB6DC572CA58F3C5D5 /* util.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		82D5C0A1EB64670CE46081210A41AD8B /* UIView+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = F83A99AE3895216765C532D36951A1D2 /* UIView+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8445B7D9F0377EF82100C01871C8D9E2 /* Thenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2270F53468815DE0FC08756D6CCFA341 /* Thenable.swift */; };
+		84724F5B857D00F41A35A247B3A278BD /* num.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C8DCB88CC65385A49D845D5907D311D /* num.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		8831B4426EE40154CFDBD55D26166C0E /* UIViewController+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FA5CE28CE7C060A546BAD90B222B573 /* UIViewController+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8C28B448DDF7BA321701C511819A5A21 /* Pods-VcNetworking-VcNetworkingTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DA35576EF1835E96B3BAAF86A6863E83 /* Pods-VcNetworking-VcNetworkingTests-dummy.m */; };
+		8DBBE5C3EBDBB182829890B8AAA26356 /* Pods-VcCrypto-VcCryptoTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A0A196DDAC0BB85EE15E8319C4D3379 /* Pods-VcCrypto-VcCryptoTests-dummy.m */; };
+		8E6A9D3B93C576616729CDADBE48A532 /* scalar.h in Headers */ = {isa = PBXBuildFile; fileRef = 19FD5BA70C94540554C882446158858B /* scalar.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		8EAA67BB5325445D89AB40CFAAC2D8C1 /* lax_der_privatekey_parsing.c in Sources */ = {isa = PBXBuildFile; fileRef = D000FD533E4085400D819CE04E649689 /* lax_der_privatekey_parsing.c */; };
+		8FA5303831C7F11D5E98DC8A38FF05DB /* Pods-VcCrypto-VcCryptoTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = DC1A8979053D9CEF9AC5A00E418B4BCA /* Pods-VcCrypto-VcCryptoTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8FDE0012D19F7BE581A08A1C60F56070 /* LogEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01F930C93559DD4B9F420D5D237E6C9 /* LogEvent.swift */; };
+		928F97F6949B4E9E6747BA327CA6D5B1 /* lax_der_parsing.c in Sources */ = {isa = PBXBuildFile; fileRef = 963CB0AA85418F81F9A57689163ACD89 /* lax_der_parsing.c */; };
+		93650CA8A56322E0184BFC80AAE18A12 /* Pods-VcCrypto-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A5FABFD3DF1528E7F959C40B23727338 /* Pods-VcCrypto-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94467C87C474A8D41C309A5133A8B675 /* UIViewPropertyAnimator+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B1986B76BE8BFA1F47E63519975F7A /* UIViewPropertyAnimator+Promise.swift */; };
+		9704BD569F465A2D6B5EC452D3E8CFE2 /* basic-config.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A6B33191F8222535EDB4F35440E942C /* basic-config.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		99555576AD055A0859DD52D9264E4CBB /* Pods-sdk-sdkTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 196F6FCE438FF2073C21110387EABEE1 /* Pods-sdk-sdkTests-dummy.m */; };
+		9A85128E12ED34C4C5FDA9CADA876462 /* ecdsa_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = E7DA78A45CEFDA2BD66E6E5BD437B1B9 /* ecdsa_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9B0118B72E0FB5FCE33187FD43E94137 /* eckey.h in Headers */ = {isa = PBXBuildFile; fileRef = 1897E6D2765165B3D189B16520A04922 /* eckey.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9C7DC10D67B24CA46E70D2C674FEAD1B /* ecdsa.h in Headers */ = {isa = PBXBuildFile; fileRef = D727184A6E2EA9D853BA156FB0E2DD05 /* ecdsa.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9D1156FDFC60ED30C80F2009BEC3DE76 /* ecmult_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = A0AE03803CB1B486BF7739D28DE295C1 /* ecmult_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9F60C4BD58F2FB9F024EDD5281727456 /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4353F498EF4D62AA7DBFE28F3E5F8320 /* after.swift */; };
+		A38111C63BA9D2A040554DE79EE13813 /* ecmult_const_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C7967D76BD5422CD8624857B4078167 /* ecmult_const_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A6984C97150DC9D8A271FBCBBC1DCA54 /* race.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5371667600D079FC77568EE611CC1267 /* race.swift */; };
+		A764BF9C3A45EC887EFD0EAB01E935CC /* NSObject+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EFEE9B9328F545CE210D88B3810EC8 /* NSObject+Promise.swift */; };
+		A7D32BDB7BEEBE2C2F217E15ECE5D1A0 /* main_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = E904D2F45316FC04196883E3BED455A8 /* main_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A81C8D7C62F3454A61F7ADCC89C96990 /* AnyPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96E0F7600B891D2D2D4C7B9138C1B0B /* AnyPromise.swift */; };
+		A84F84F824A6025C19286C54A1CA76AF /* Pods-sdk-sdkTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1145C86F40C2887868145ED75A33CFE2 /* Pods-sdk-sdkTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AD058298CC455015A3802D257DAA94BE /* Pods-VcNetworking-VcNetworkingTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 95ADB8E4CAD8828B1BF6FB48F33CF488 /* Pods-VcNetworking-VcNetworkingTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B6466FD0ABC0E5E98497B6384B063401 /* hang.m in Sources */ = {isa = PBXBuildFile; fileRef = 42014D231E070D573934F2D44AE6706D /* hang.m */; };
+		B6FD9430FB9CCFE50E93DE797E519FCC /* UIViewController+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 3730C8C8F50BAFB7408B176B346076CB /* UIViewController+AnyPromise.m */; };
+		B8FF6723C422C3C93D8446A935CA80C6 /* scratch.h in Headers */ = {isa = PBXBuildFile; fileRef = BCFF8CAACC2DE737E452F090CF9E6254 /* scratch.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BAA5F14DE796A70EDCD10338993AB66E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
+		BB37D18AEF801324A67C9BE130439907 /* scalar_8x32_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = E881A39F7EEB33AD66E34B200A5476EC /* scalar_8x32_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC0F7B6696E14DFB8EC79D1E071864E2 /* Pods-VcNetworking-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F37EDB0E21047DD31A051CC54A1C2E28 /* Pods-VcNetworking-dummy.m */; };
+		C4343A9A01F4D90B9B98C30806FC050D /* scalar_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = D4A74638C4ED8D0224F351F76E29991A /* scalar_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CB3829655DEDB456332BABDF0E59CEAA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
+		CBE0628C41374467DAD7D28C6BB0DECE /* Catchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15BEF5399736F43655C01758148FEA87 /* Catchable.swift */; };
+		CDB8859DB8D7A7AEB3CDA3AC896800BB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
+		D04A7984E0B5A3A092F6DD2FB4B6EA26 /* join.m in Sources */ = {isa = PBXBuildFile; fileRef = 243ECF8B1AF363D562935D9D329BEA2A /* join.m */; };
+		D3ECE45BA61EB7CF0EEAC491F1D8BE97 /* lax_der_privatekey_parsing.h in Headers */ = {isa = PBXBuildFile; fileRef = E80CBCCF2CEE58DD6AA7B3689BD17DA6 /* lax_der_privatekey_parsing.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D63DEBA99E5A3FA2A9A816EBECB31D1B /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28FE3E8C393FA4C5D3C55E303F6643E /* Box.swift */; };
+		D7771ACA5665C207C30C5366F6D0F90D /* num_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 66EBE3D286B36B60CC645AA66BBCDD9F /* num_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D84861ED689D035C63609B0654986E3D /* scratch_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = CD4D03B1A375066A4DB77D0E462E918D /* scratch_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		DA9B0143EAEDB56BF439C761C55C87F8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */; };
+		DD0DCDDF37A406834613483F10DE8296 /* UIView+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D9E0A291B69EAF8057416D377913C49 /* UIView+AnyPromise.m */; };
+		E0190E57023E33FE1F47BF14BEEA7B56 /* hash_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = C26428FE936F8E44D28B7EF6EF32A837 /* hash_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E59846B9FE72CE029F212C6B52C00435 /* field_5x52_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 4030316DDADF3632794E6A712C7C35C4 /* field_5x52_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E6CF645B0BA0747D65D0A1D978FD97C1 /* Pods-VcJwt-VcJwtTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F74A67686579616885C47FBDEE16D7D /* Pods-VcJwt-VcJwtTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E813DB8CC70E6123A7C7FBAE0E504B81 /* PMKFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = B683C4D0E6E23E3F79339391D128B996 /* PMKFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E8A0C6676AFC75F7CF236D5CC7F74BB0 /* PMKUIKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AC6A930480C6D49FBE9CABC861E7B9F /* PMKUIKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E9AB9896FCF00E661FF0FDD11716487C /* NSURLSession+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F81E3F134B8E512031BF48D62DEAD8D /* NSURLSession+Promise.swift */; };
+		EA5977C16C7EC9B9DE9E72B370EFF0B5 /* ecmult_gen.h in Headers */ = {isa = PBXBuildFile; fileRef = DD76667382B20B88BB8935E1812CE344 /* ecmult_gen.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EBE4BD3D7C8F8F00CAF808438B23A1A0 /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F2F95317A023EF6B665F27F5306CCD /* Promise.swift */; };
+		EC4A2AF0DE9B68764ECAD72D0F3C5EAB /* after.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E05F323974C2D7833417A8D7F5BF127 /* after.m */; };
+		EDAFD563D61F53D4C97920A42EF7895D /* Pods-sdk-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 24EB90B5CFEE83BC4C39D3C8DC878479 /* Pods-sdk-dummy.m */; };
+		EDFF7078C59974F7BB1DF334AC7C47D8 /* NSNotificationCenter+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C65CC0177A8C20AED52EEEA3B2271AC /* NSNotificationCenter+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EF3A12CAD983F86CD5CBFA744B2612A6 /* when.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC78C53213A88D95B49A8F6B925B1555 /* when.swift */; };
+		EF6DA14F252481AD22FADAF253829E29 /* PromiseKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5486BABF44C7078871EADFE753E1A38A /* PromiseKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F11A4AB7236A85C47FA9B33B00A224D4 /* Process+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E557CC48D00AA85F709DBA6037FBC2 /* Process+Promise.swift */; };
+		F3130E6206ACC486720380339D54E1EA /* PromiseKit.h in Headers */ = {isa = PBXBuildFile; fileRef = EB522A7F729177C33D085ABD72CA65F6 /* PromiseKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F413DC82A060E79EC20CED3E9994CCC6 /* NSNotificationCenter+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62A210C649AF5DFF8193A3D6CF19B15 /* NSNotificationCenter+Promise.swift */; };
+		F4643B26A69537390AC94A9F3017DC26 /* ecmult.h in Headers */ = {isa = PBXBuildFile; fileRef = 9341A118F888C938C6A921D4C480EF20 /* ecmult.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FA72F55097C107BCC053CC59D04EE3C5 /* field_5x52.h in Headers */ = {isa = PBXBuildFile; fileRef = AB7EDE0742AFF5F3232CDA094EB7A124 /* field_5x52.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FB81AF64500747F8A86BF49639A23478 /* scalar_4x64.h in Headers */ = {isa = PBXBuildFile; fileRef = 1211768920E8D71136FB3AC4C9C3AEEC /* scalar_4x64.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FB93092887EF773B16F5E4544ADA4E2B /* NSTask+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FCC8EEC3595B913B19D91A502CF2E79 /* NSTask+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FD7DF70E33BAB15E17DF298C74CD6FAC /* NSNotificationCenter+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = B3CE95F3C13990139072A473BAA550A7 /* NSNotificationCenter+AnyPromise.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		15FEDFFAF1E043D37DF5D7A836B6D9E3 /* PBXContainerItemProxy */ = {
+		069B24003BF95424FDEDA5579C59ABCC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 37DBAFDC20E13984CC335B195F5E85D9;
 			remoteInfo = VcNetworking;
 		};
-		16A3D9D084EE6A7ACABE07A6C7859480 /* PBXContainerItemProxy */ = {
+		0ED169543E35C8512891EE13FF42930E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 3020FF5BE409E86C04853BBDEF3E50A7;
-			remoteInfo = "bitcoin-core-secp256k1";
+			remoteGlobalIDString = 7C579CE66A1E7A9AA33CA5F97F9C22C5;
+			remoteInfo = PromiseKit;
 		};
-		1BC9530B95CD2CAAECCCB0E432259E49 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 9AE68C3D8E67C47FB2C8E83198549C5F;
-			remoteInfo = VcCrypto;
-		};
-		3F37E650BBC111E5DB58D6D8570226E7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3020FF5BE409E86C04853BBDEF3E50A7;
-			remoteInfo = "bitcoin-core-secp256k1";
-		};
-		44A774CCD9F7984737025616B23E8A69 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3020FF5BE409E86C04853BBDEF3E50A7;
-			remoteInfo = "bitcoin-core-secp256k1";
-		};
-		49D91120CF23E43C39F921D865712EC6 /* PBXContainerItemProxy */ = {
+		289B305BD9F1ABC023F45A6AF030CC3D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 37DBAFDC20E13984CC335B195F5E85D9;
 			remoteInfo = VcNetworking;
 		};
-		6E2177128E222F1AD6BB3615CC96B60F /* PBXContainerItemProxy */ = {
+		2F46C7CF33996C30CE7D18F42191290A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A2701971E9F776D08826CE4ABC57817F;
+			remoteInfo = secp256k1_ios;
+		};
+		37006E3BD8E1AB7395F762A4E8441866 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 7C579CE66A1E7A9AA33CA5F97F9C22C5;
 			remoteInfo = PromiseKit;
 		};
-		7251087F3587965D8387D0FE2E4C7DED /* PBXContainerItemProxy */ = {
+		3899DCA2E665ED9340FDF1166A4B6327 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A2701971E9F776D08826CE4ABC57817F;
+			remoteInfo = secp256k1_ios;
+		};
+		54C7AD8EDD3BAC400F928EDBD560C915 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 9AE68C3D8E67C47FB2C8E83198549C5F;
 			remoteInfo = VcCrypto;
 		};
-		7F708D884864F4BE02013D4E46BDBE00 /* PBXContainerItemProxy */ = {
+		A1B7341F04D6251F408A4BE614D694BA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A2701971E9F776D08826CE4ABC57817F;
+			remoteInfo = secp256k1_ios;
+		};
+		A5AFD41BE6CCE8C1C8F3F0FD7D286231 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A2701971E9F776D08826CE4ABC57817F;
+			remoteInfo = secp256k1_ios;
+		};
+		CC30210DB30EA14FA994CFD07859FFF1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9AE68C3D8E67C47FB2C8E83198549C5F;
+			remoteInfo = VcCrypto;
+		};
+		D7EEA0D182ADC386BD2B9ADA9735A579 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 7C579CE66A1E7A9AA33CA5F97F9C22C5;
 			remoteInfo = PromiseKit;
 		};
-		A64009CE24A51E68AB404C77505A1A72 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3020FF5BE409E86C04853BBDEF3E50A7;
-			remoteInfo = "bitcoin-core-secp256k1";
-		};
-		AB4995975A5BD79F01E8DB41F6D8ADFE /* PBXContainerItemProxy */ = {
+		E2D772DE5757C7F34F08C7263230965F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 7C579CE66A1E7A9AA33CA5F97F9C22C5;
 			remoteInfo = PromiseKit;
 		};
-		E3E0366F469EFA877271E0B1BDF1B6C3 /* PBXContainerItemProxy */ = {
+		FA29145037473CDC063B6631505442BB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 7C579CE66A1E7A9AA33CA5F97F9C22C5;
 			remoteInfo = PromiseKit;
 		};
-		F6187785962DE84510431815E226833F /* PBXContainerItemProxy */ = {
+		FF6A7AAC28BDDC570153D3567E130883 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7C579CE66A1E7A9AA33CA5F97F9C22C5;
-			remoteInfo = PromiseKit;
-		};
-		FE952EC7C5C84483717621FEEDABC7E3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3020FF5BE409E86C04853BBDEF3E50A7;
-			remoteInfo = "bitcoin-core-secp256k1";
+			remoteGlobalIDString = A2701971E9F776D08826CE4ABC57817F;
+			remoteInfo = secp256k1_ios;
 		};
 /* End PBXContainerItemProxy section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		7724A5C30DD8B8A784458B3F7DA5D824 /* Copy include Public Headers */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "$(PUBLIC_HEADERS_FOLDER_PATH)/include";
-			dstSubfolderSpec = 16;
-			files = (
-				EBD2442574C3F059F2F2AAA86CF088B2 /* secp256k1.h in Copy include Public Headers */,
-				8215B8CC79A345D254F6388D9348C3A1 /* secp256k1_ecdh.h in Copy include Public Headers */,
-				495E6F821F16C52B42444B79176B3093 /* secp256k1_preallocated.h in Copy include Public Headers */,
-				9E7F1714C21BB42C01032F4E2BF98F61 /* secp256k1_recovery.h in Copy include Public Headers */,
-			);
-			name = "Copy include Public Headers";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D135A680FBC3E227BBC77B52F877E0FE /* Copy src Private Headers */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "$(PRIVATE_HEADERS_FOLDER_PATH)/src";
-			dstSubfolderSpec = 16;
-			files = (
-				BB1E618B1BD4B77570BBFCDE02F11F8E /* assumptions.h in Copy src Private Headers */,
-				9F38F14D55B31C69D46E9F36C663AE3F /* basic-config.h in Copy src Private Headers */,
-				7A31D823DFAE2E054E30AAE454B98432 /* ecdsa.h in Copy src Private Headers */,
-				8C15DCDFD43578EDA5EF25BDAC664ED6 /* ecdsa_impl.h in Copy src Private Headers */,
-				3A8A39A2CC51F46073A638BF0D3CFA8A /* eckey.h in Copy src Private Headers */,
-				AC189AB1FE874B42B98EDF41A8AC974E /* eckey_impl.h in Copy src Private Headers */,
-				40453F3F1904D3880F1D9F5865614375 /* ecmult.h in Copy src Private Headers */,
-				30ECF1F8A95BF3A742F9F8FBD0151BF0 /* ecmult_const.h in Copy src Private Headers */,
-				44E9EDDEEA8C5B9712048F9D065B6C4C /* ecmult_const_impl.h in Copy src Private Headers */,
-				49325C685ACD95BB2A71E4FA951A87F5 /* ecmult_gen.h in Copy src Private Headers */,
-				AA80180AEE71E25004BB4B17EDEDD464 /* ecmult_gen_impl.h in Copy src Private Headers */,
-				902AF9717AB07CE7D8C982D0E603A68C /* ecmult_impl.h in Copy src Private Headers */,
-				F425B8776B8206D5DC57D6A8B70BCD58 /* field.h in Copy src Private Headers */,
-				4CE92A0F3E2AB2BD3CB7CC6389A83FC7 /* field_10x26.h in Copy src Private Headers */,
-				8EF64DB263F87A20BFBF819CF387A513 /* field_10x26_impl.h in Copy src Private Headers */,
-				2B2F29CCC0E00B3CCADE66C7ECC19081 /* field_5x52.h in Copy src Private Headers */,
-				7BCDE06FCA0E5D3ECC1CD83695A9F1C6 /* field_5x52_asm_impl.h in Copy src Private Headers */,
-				3013FBBA8D4A9BCE7568AF4DFF39812F /* field_5x52_impl.h in Copy src Private Headers */,
-				AE8A2FF70E1FF19F05385C9465FBA051 /* field_5x52_int128_impl.h in Copy src Private Headers */,
-				2277BCFF84E184ADBABCB2C218E1CE00 /* field_impl.h in Copy src Private Headers */,
-				A3DF146CF00ABFBEEEB93CA8C98E4A0F /* group.h in Copy src Private Headers */,
-				3BB3B3EDD1071473F621506B75B57E86 /* group_impl.h in Copy src Private Headers */,
-				1CEDE74CCF37034825911D9E3D864D6A /* hash.h in Copy src Private Headers */,
-				1EE6E859C9F803756B432B28FDE78DBB /* hash_impl.h in Copy src Private Headers */,
-				9FD195E2521B0D49C1E8DF74D047383C /* num.h in Copy src Private Headers */,
-				54806BFF8A94540CA146BCD4337C081C /* num_gmp.h in Copy src Private Headers */,
-				9699808CCF1174CD4D51ACCB3A3F6988 /* num_gmp_impl.h in Copy src Private Headers */,
-				799323431ABB06FFAFD8C5ED23161212 /* num_impl.h in Copy src Private Headers */,
-				CD94BBCACE341F873B1D51C641736C0F /* scalar.h in Copy src Private Headers */,
-				70FD9DF9CE7DEF7EC6818EF9703B8CCC /* scalar_4x64.h in Copy src Private Headers */,
-				0C7FE14DF3D75AEA6BCDAEFDF6D16BE6 /* scalar_4x64_impl.h in Copy src Private Headers */,
-				2FF9F44E2B1557815134D2FD52694E4B /* scalar_8x32.h in Copy src Private Headers */,
-				CE6F1D94FE37E625ECB61BB9980BF5F6 /* scalar_8x32_impl.h in Copy src Private Headers */,
-				E9115666403292A31A2B75BBB9D12C26 /* scalar_impl.h in Copy src Private Headers */,
-				ED79F258409E99BB8CB18994697BAFEF /* scalar_low.h in Copy src Private Headers */,
-				E88FEC7862E707146C09810A14DFC44C /* scalar_low_impl.h in Copy src Private Headers */,
-				5E72C91F7BB69C8984571EEE4824CA56 /* scratch.h in Copy src Private Headers */,
-				605D8FABF466627ABDAD7388EBE669E8 /* scratch_impl.h in Copy src Private Headers */,
-				F64C538EDB0C6BB9EAFA17BF98D8BA99 /* util.h in Copy src Private Headers */,
-			);
-			name = "Copy src Private Headers";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXFileReference section */
 		002B1E88BA14EBF633CD66EBFBA107E9 /* PromiseKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = PromiseKit.framework; path = PromiseKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		03EA20861088FACDC61C8C51E1FAF700 /* Guarantee.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Guarantee.swift; path = Sources/Guarantee.swift; sourceTree = "<group>"; };
 		0421A70AF7B3109297422E3D8F394BAE /* Pods_sdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_sdk.framework; path = "Pods-sdk.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		04DE1D978C2B59117A5735206C047D69 /* tests_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = tests_impl.h; path = src/modules/recovery/tests_impl.h; sourceTree = "<group>"; };
+		05EE3D1F1EAAB7A8F7D94CFDDCB73990 /* field_5x52_asm_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52_asm_impl.h; path = secp256k1_ios/src/field_5x52_asm_impl.h; sourceTree = "<group>"; };
 		062F2FD1E832F60DC72B992A028A1A82 /* Pods-VcJwt-VcJwtTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VcJwt-VcJwtTests.debug.xcconfig"; sourceTree = "<group>"; };
+		06C3BAEBD327280F000B6BEE407EB681 /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Error.swift; path = Sources/Error.swift; sourceTree = "<group>"; };
 		07EAED9DE7C9C6F3FE2BD665FEA7BDE3 /* Pods-VcCrypto.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VcCrypto.debug.xcconfig"; sourceTree = "<group>"; };
-		0835F553980ECBAC01CDB6FB67646096 /* VcNetworking.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = VcNetworking.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		0894F527EF50033A03AB4F13D833DCE2 /* Pods_sdk_sdkTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_sdk_sdkTests.framework; path = "Pods-sdk-sdkTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		092C8A6D04604C2959105D64F9C965C9 /* scalar.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar.h; path = src/scalar.h; sourceTree = "<group>"; };
-		0AB30D83F5947CFF59E69DFEE6520A2A /* field_5x52_int128_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52_int128_impl.h; path = src/field_5x52_int128_impl.h; sourceTree = "<group>"; };
-		0C63CCB86A6BC83026C7E55E16E2B45E /* NSTask+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSTask+AnyPromise.h"; path = "Extensions/Foundation/Sources/NSTask+AnyPromise.h"; sourceTree = "<group>"; };
 		0F7776BC5D59C957737CE50CF212C748 /* Pods-VcJwt.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VcJwt.release.xcconfig"; sourceTree = "<group>"; };
-		0FD960E5387CEF78BCE09BD9B0D7E080 /* PMKFoundation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PMKFoundation.h; path = Extensions/Foundation/Sources/PMKFoundation.h; sourceTree = "<group>"; };
-		11072080A5FE47752615651BC0F878CB /* secp256k1.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1.h; path = include/secp256k1.h; sourceTree = "<group>"; };
+		10711BE548AED40F4C2EE0422167D557 /* secp256k1_recovery.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1_recovery.h; path = secp256k1_ios/include/secp256k1_recovery.h; sourceTree = "<group>"; };
 		1145C86F40C2887868145ED75A33CFE2 /* Pods-sdk-sdkTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-sdk-sdkTests-umbrella.h"; sourceTree = "<group>"; };
+		1211768920E8D71136FB3AC4C9C3AEEC /* scalar_4x64.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_4x64.h; path = secp256k1_ios/src/scalar_4x64.h; sourceTree = "<group>"; };
 		12B7A5A26509C474625F6F3775AA9A93 /* Pods-sdk-sdkTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-sdk-sdkTests-frameworks.sh"; sourceTree = "<group>"; };
-		12DC8F7031D40A0A47C4F18F42315CAC /* LogEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LogEvent.swift; path = Sources/LogEvent.swift; sourceTree = "<group>"; };
 		1476EE41D7C691B74BFDAB76A7BC87CE /* Pods-VcJwt-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VcJwt-Info.plist"; sourceTree = "<group>"; };
+		14F2F95317A023EF6B665F27F5306CCD /* Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Promise.swift; path = Sources/Promise.swift; sourceTree = "<group>"; };
 		1533A6005727A8948352AC303001D7F0 /* Pods-VcJwt-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VcJwt-acknowledgements.markdown"; sourceTree = "<group>"; };
-		1769986EB7E8D241D2DD7CC4E6521A67 /* bitcoin-core-secp256k1-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "bitcoin-core-secp256k1-umbrella.h"; sourceTree = "<group>"; };
+		15BEF5399736F43655C01758148FEA87 /* Catchable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Catchable.swift; path = Sources/Catchable.swift; sourceTree = "<group>"; };
+		16A9AC73D66FC840307B490F032B64C9 /* secp256k1_ios-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "secp256k1_ios-Info.plist"; sourceTree = "<group>"; };
+		174ED2AFD0A4B7DD241777987932DDD5 /* group_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = group_impl.h; path = secp256k1_ios/src/group_impl.h; sourceTree = "<group>"; };
 		180CFB385DEC15A7AA5DAFF7CA90138B /* Pods-sdk.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-sdk.debug.xcconfig"; sourceTree = "<group>"; };
-		1848FB9DB0AE45FF4D680907B0E98523 /* NSNotificationCenter+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNotificationCenter+AnyPromise.m"; path = "Extensions/Foundation/Sources/NSNotificationCenter+AnyPromise.m"; sourceTree = "<group>"; };
-		18A1EBCA4C05FA2B762860A43B9F655E /* PromiseKit-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "PromiseKit-Info.plist"; sourceTree = "<group>"; };
-		19467827B2F45A595370C58513268EDB /* NSURLSession+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSURLSession+AnyPromise.m"; path = "Extensions/Foundation/Sources/NSURLSession+AnyPromise.m"; sourceTree = "<group>"; };
+		1897E6D2765165B3D189B16520A04922 /* eckey.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = eckey.h; path = secp256k1_ios/src/eckey.h; sourceTree = "<group>"; };
 		196F6FCE438FF2073C21110387EABEE1 /* Pods-sdk-sdkTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-sdk-sdkTests-dummy.m"; sourceTree = "<group>"; };
-		1AB72A6669EFC71F29FFE5B951A85B64 /* basic-config.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "basic-config.h"; path = "src/basic-config.h"; sourceTree = "<group>"; };
-		1BFEBCBBC1EDAFBB554B2FCCFBF5B5D0 /* tests_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = tests_impl.h; path = src/modules/ecdh/tests_impl.h; sourceTree = "<group>"; };
-		1C04FB4E47DE959155FC5E512E26D630 /* ecmult_gen.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_gen.h; path = src/ecmult_gen.h; sourceTree = "<group>"; };
+		19FD5BA70C94540554C882446158858B /* scalar.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar.h; path = secp256k1_ios/src/scalar.h; sourceTree = "<group>"; };
+		1A6B33191F8222535EDB4F35440E942C /* basic-config.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "basic-config.h"; path = "secp256k1_ios/src/basic-config.h"; sourceTree = "<group>"; };
+		1BE938727019BB721FCF3A08FBD11E3C /* Deprecations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Deprecations.swift; path = Sources/Deprecations.swift; sourceTree = "<group>"; };
 		1D70AD3EB826FBBFEDB30FE7AA4E88A6 /* Pods-VcCrypto-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VcCrypto-Info.plist"; sourceTree = "<group>"; };
 		1EFF9422A799E7A7733D6C306A5BE53B /* Pods-VcNetworking-VcNetworkingTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VcNetworking-VcNetworkingTests-Info.plist"; sourceTree = "<group>"; };
 		20FD9B8F0A22A3347D5A8841CDB0524C /* Pods-VcCrypto-VcCryptoTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VcCrypto-VcCryptoTests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		21E61B955C6DCF3B115F398121FF0A43 /* ecmult_gen_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_gen_impl.h; path = src/ecmult_gen_impl.h; sourceTree = "<group>"; };
-		220DA8A861A195B90F9F7D54C61E3B56 /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Configuration.swift; path = Sources/Configuration.swift; sourceTree = "<group>"; };
-		228C193C5D97130985D9AB568E3E7F86 /* bitcoin_core_secp256k1.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = bitcoin_core_secp256k1.framework; path = "bitcoin-core-secp256k1.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2270F53468815DE0FC08756D6CCFA341 /* Thenable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Thenable.swift; path = Sources/Thenable.swift; sourceTree = "<group>"; };
 		2293345F167A1CB10E6BEEFE9C344697 /* Pods-VcCrypto-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VcCrypto-acknowledgements.markdown"; sourceTree = "<group>"; };
+		23DE15C88C33ED4A73994B094C2643E3 /* field_10x26_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_10x26_impl.h; path = secp256k1_ios/src/field_10x26_impl.h; sourceTree = "<group>"; };
+		243ECF8B1AF363D562935D9D329BEA2A /* join.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = join.m; path = Sources/join.m; sourceTree = "<group>"; };
 		247291DE9733310CF8C236C5BC55B298 /* Pods-sdk.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-sdk.modulemap"; sourceTree = "<group>"; };
 		24EB90B5CFEE83BC4C39D3C8DC878479 /* Pods-sdk-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-sdk-dummy.m"; sourceTree = "<group>"; };
-		254036BDF02E8B5E0A0B3B8474AFF790 /* field_5x52.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52.h; path = src/field_5x52.h; sourceTree = "<group>"; };
-		2817BCFFD9EBF0A304905121E1824141 /* util.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = util.h; path = src/util.h; sourceTree = "<group>"; };
 		282D6083A00FF4B040ADB95EED14BCD5 /* Pods-VcNetworking-VcNetworkingTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VcNetworking-VcNetworkingTests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		28611D9E122BE6A33ECAAD15BE28D8C9 /* Pods-VcJwt-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VcJwt-acknowledgements.plist"; sourceTree = "<group>"; };
-		29C74ECC00EE31C2D221E471208650E3 /* scalar_8x32_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_8x32_impl.h; path = src/scalar_8x32_impl.h; sourceTree = "<group>"; };
+		2A4B21AB340724F56E2462F8F700278F /* num_gmp_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num_gmp_impl.h; path = secp256k1_ios/src/num_gmp_impl.h; sourceTree = "<group>"; };
 		2B5B93F38F19F3082CFD2F55752F335E /* Pods_VcJwt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VcJwt.framework; path = "Pods-VcJwt.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		2FADC424BE7BF6C4154E9EEC1C2D6B37 /* scratch_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scratch_impl.h; path = src/scratch_impl.h; sourceTree = "<group>"; };
 		312B988EF117AE4DE76A268D970131FE /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		318457D8455B7767DAFB37BB9C322DEC /* Pods-VcCrypto-VcCryptoTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VcCrypto-VcCryptoTests-acknowledgements.plist"; sourceTree = "<group>"; };
-		31F2466A7E8D153CA95BF23E8513F91E /* bitcoin-core-secp256k1-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "bitcoin-core-secp256k1-Info.plist"; sourceTree = "<group>"; };
-		3237E0A6AFFEDEFA869A0B935911434A /* NSTask+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSTask+AnyPromise.m"; path = "Extensions/Foundation/Sources/NSTask+AnyPromise.m"; sourceTree = "<group>"; };
-		360908940B4F77BADE3771D2B9439229 /* when.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = when.swift; path = Sources/when.swift; sourceTree = "<group>"; };
-		36F921352F9288D40551163CBCE6FA1E /* UIViewController+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+AnyPromise.m"; path = "Extensions/UIKit/Sources/UIViewController+AnyPromise.m"; sourceTree = "<group>"; };
+		329A591E9BEEE33DE0B2644FBBAB3ED0 /* ecmult_gen_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_gen_impl.h; path = secp256k1_ios/src/ecmult_gen_impl.h; sourceTree = "<group>"; };
+		3500F51E4117B09F15D007270B88AE4A /* race.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = race.m; path = Sources/race.m; sourceTree = "<group>"; };
+		3730C8C8F50BAFB7408B176B346076CB /* UIViewController+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+AnyPromise.m"; path = "Extensions/UIKit/Sources/UIViewController+AnyPromise.m"; sourceTree = "<group>"; };
 		382B6C94E311CC8E1A255AE88C7C92F6 /* Pods-VcNetworking-VcNetworkingTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VcNetworking-VcNetworkingTests.debug.xcconfig"; sourceTree = "<group>"; };
 		398CA9DBF2BCA700DB27CBC26C8213CA /* Pods-VcJwt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VcJwt.debug.xcconfig"; sourceTree = "<group>"; };
-		3B28B2A2E81B13D1C160294EBE8DA74D /* PromiseKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PromiseKit-dummy.m"; sourceTree = "<group>"; };
+		3A29BF806D25C7FB68DA035F723BCE26 /* secp256k1_ios.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1_ios.h; path = secp256k1_ios/secp256k1_ios.h; sourceTree = "<group>"; };
 		3BEE82B0FED60433BF1663D6B7A368F0 /* Pods-VcCrypto-VcCryptoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VcCrypto-VcCryptoTests.debug.xcconfig"; sourceTree = "<group>"; };
-		3CDA2CD70FF5E2272DA0F95B8EE4EEDB /* eckey_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = eckey_impl.h; path = src/eckey_impl.h; sourceTree = "<group>"; };
+		3C8A62387E870EA43D03CA53DCEE0C1D /* field_10x26.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_10x26.h; path = secp256k1_ios/src/field_10x26.h; sourceTree = "<group>"; };
 		3D3AB09513FFD7D78E99FFBFB09F6A12 /* Pods-VcJwt-VcJwtTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VcJwt-VcJwtTests-acknowledgements.plist"; sourceTree = "<group>"; };
 		3F74A67686579616885C47FBDEE16D7D /* Pods-VcJwt-VcJwtTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VcJwt-VcJwtTests-umbrella.h"; sourceTree = "<group>"; };
-		41E581E84D52D93CC8F265CBF419028E /* bitcoin-core-secp256k1-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "bitcoin-core-secp256k1-prefix.pch"; sourceTree = "<group>"; };
-		4315C0CC711137AAEB92AFEA7D43D25A /* fwd.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = fwd.h; path = Sources/fwd.h; sourceTree = "<group>"; };
+		3FA5CE28CE7C060A546BAD90B222B573 /* UIViewController+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIViewController+AnyPromise.h"; path = "Extensions/UIKit/Sources/UIViewController+AnyPromise.h"; sourceTree = "<group>"; };
+		4030316DDADF3632794E6A712C7C35C4 /* field_5x52_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52_impl.h; path = secp256k1_ios/src/field_5x52_impl.h; sourceTree = "<group>"; };
+		42014D231E070D573934F2D44AE6706D /* hang.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = hang.m; path = Sources/hang.m; sourceTree = "<group>"; };
+		42183EE1C6E2CBE0704C8213F9D97712 /* secp256k1.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1.h; path = secp256k1_ios/include/secp256k1.h; sourceTree = "<group>"; };
+		4353F498EF4D62AA7DBFE28F3E5F8320 /* after.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = after.swift; path = Sources/after.swift; sourceTree = "<group>"; };
 		436BAA54A31999B53B3CC7115C55FE50 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		474EB8FDCD80C8B9B1C48E130D9C4C7E /* VcCrypto.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = VcCrypto.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		47C21771D239B20B2491846F2B5ABC63 /* Pods-VcJwt-VcJwtTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VcJwt-VcJwtTests-dummy.m"; sourceTree = "<group>"; };
-		49CA7A569C295010860D536FCC3324BF /* Process+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Process+Promise.swift"; path = "Extensions/Foundation/Sources/Process+Promise.swift"; sourceTree = "<group>"; };
-		4A7EF5955F461D82227208AFCEDECA69 /* hang.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = hang.m; path = Sources/hang.m; sourceTree = "<group>"; };
+		480FC1D442C11B3F90011531FD2A997E /* Resolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Resolver.swift; path = Sources/Resolver.swift; sourceTree = "<group>"; };
+		48DD6794BCB3DF6CB5BA5BFAE048B60A /* PromiseKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = PromiseKit.modulemap; sourceTree = "<group>"; };
+		4A1767B5AD12E1BB6DC572CA58F3C5D5 /* util.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = util.h; path = secp256k1_ios/src/util.h; sourceTree = "<group>"; };
+		4A3312121FB6F7D6B4479466A46AD072 /* PromiseKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PromiseKit.release.xcconfig; sourceTree = "<group>"; };
 		4AE0F0DFA89130C50F8620807B62715A /* Pods_VcNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VcNetworking.framework; path = "Pods-VcNetworking.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		4CA73410BAD385AFACD9732A9996859E /* field_5x52_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52_impl.h; path = src/field_5x52_impl.h; sourceTree = "<group>"; };
+		4B214A3CA7FE949A02513F6722C0C2D0 /* ecmult_const.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_const.h; path = secp256k1_ios/src/ecmult_const.h; sourceTree = "<group>"; };
 		4CB48C6C7449DF85C029C2C01A34128C /* Pods-sdk-sdkTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-sdk-sdkTests-acknowledgements.plist"; sourceTree = "<group>"; };
-		4CBA08A665295E2056C26FFEBDD34ADC /* scalar_4x64.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_4x64.h; path = src/scalar_4x64.h; sourceTree = "<group>"; };
-		4D555BB7F954235881771E11B587CF7D /* group_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = group_impl.h; path = src/group_impl.h; sourceTree = "<group>"; };
-		4D78F27BB75E50CD2FD6188C55E27373 /* ecmult_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_impl.h; path = src/ecmult_impl.h; sourceTree = "<group>"; };
 		4DF8D04C1F5CBE76FF631A0B4F81FB5E /* Pods-sdk-sdkTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-sdk-sdkTests.release.xcconfig"; sourceTree = "<group>"; };
-		4F3593DF8DEA8D63547441DC7AC2A080 /* join.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = join.m; path = Sources/join.m; sourceTree = "<group>"; };
-		50DDFDB314A42CE9CC5746DF0AC0D1E5 /* scalar_8x32.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_8x32.h; path = src/scalar_8x32.h; sourceTree = "<group>"; };
-		522C3CAACE0477E91BB6A3A9D9E9F663 /* dispatch_promise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = dispatch_promise.m; path = Sources/dispatch_promise.m; sourceTree = "<group>"; };
-		57F77B70178D80BF5067756DE869B9A8 /* ecdsa.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecdsa.h; path = src/ecdsa.h; sourceTree = "<group>"; };
-		59638B0B1B5532B717C69B560940EFDC /* hash_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = hash_impl.h; path = src/hash_impl.h; sourceTree = "<group>"; };
+		4E05F323974C2D7833417A8D7F5BF127 /* after.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = after.m; path = Sources/after.m; sourceTree = "<group>"; };
+		4FCC8EEC3595B913B19D91A502CF2E79 /* NSTask+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSTask+AnyPromise.h"; path = "Extensions/Foundation/Sources/NSTask+AnyPromise.h"; sourceTree = "<group>"; };
+		51CC579DCE56A91B90B9E605836D243A /* NSURLSession+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLSession+AnyPromise.h"; path = "Extensions/Foundation/Sources/NSURLSession+AnyPromise.h"; sourceTree = "<group>"; };
+		5371667600D079FC77568EE611CC1267 /* race.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = race.swift; path = Sources/race.swift; sourceTree = "<group>"; };
+		5486BABF44C7078871EADFE753E1A38A /* PromiseKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PromiseKit-umbrella.h"; sourceTree = "<group>"; };
+		55C3960246814482A3687E5F19E64CE5 /* AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AnyPromise.m; path = Sources/AnyPromise.m; sourceTree = "<group>"; };
 		5A8A488E8DB257246A94BCB49BAAA738 /* Pods-VcCrypto-VcCryptoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VcCrypto-VcCryptoTests.release.xcconfig"; sourceTree = "<group>"; };
-		5F9948ADFF702D01AEECEFAF7656A276 /* ecmult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult.h; path = src/ecmult.h; sourceTree = "<group>"; };
+		5C8DCB88CC65385A49D845D5907D311D /* num.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num.h; path = secp256k1_ios/src/num.h; sourceTree = "<group>"; };
+		5ED21860AAC5C75752EBA9698A6DED74 /* AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AnyPromise.h; path = Sources/AnyPromise.h; sourceTree = "<group>"; };
+		5F81E3F134B8E512031BF48D62DEAD8D /* NSURLSession+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSURLSession+Promise.swift"; path = "Extensions/Foundation/Sources/NSURLSession+Promise.swift"; sourceTree = "<group>"; };
 		5FF8F40C2340DF635E60E402B82715FD /* Pods-VcNetworking.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VcNetworking.release.xcconfig"; sourceTree = "<group>"; };
-		6555C520A49FE51A6FBCB72A7E4E0644 /* field_5x52_asm_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52_asm_impl.h; path = src/field_5x52_asm_impl.h; sourceTree = "<group>"; };
-		6CC0E54668B48A9784A91C016F12FED0 /* PromiseKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PromiseKit-umbrella.h"; sourceTree = "<group>"; };
+		62855D2CE3CAD80DC3B241E9F1D7EF52 /* secp256k1_ios-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "secp256k1_ios-prefix.pch"; sourceTree = "<group>"; };
+		63700342A59B39A2809E6816A2E116F5 /* PromiseKit-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "PromiseKit-Info.plist"; sourceTree = "<group>"; };
+		66EBE3D286B36B60CC645AA66BBCDD9F /* num_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num_impl.h; path = secp256k1_ios/src/num_impl.h; sourceTree = "<group>"; };
+		69CF1B9477AEE675CD98E6C7931DCC15 /* libsecp256k1-config.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "libsecp256k1-config.h"; path = "secp256k1_ios/libsecp256k1-config.h"; sourceTree = "<group>"; };
+		6AC6A930480C6D49FBE9CABC861E7B9F /* PMKUIKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PMKUIKit.h; path = Extensions/UIKit/Sources/PMKUIKit.h; sourceTree = "<group>"; };
+		6C7967D76BD5422CD8624857B4078167 /* ecmult_const_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_const_impl.h; path = secp256k1_ios/src/ecmult_const_impl.h; sourceTree = "<group>"; };
+		6CB79A2F18EFFE2B528DD29DE55DCC66 /* VcCrypto.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = VcCrypto.release.xcconfig; sourceTree = "<group>"; };
 		715955323DE003AEA88A4ECE05EDF9D1 /* Pods-VcNetworking-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VcNetworking-Info.plist"; sourceTree = "<group>"; };
-		71B2B261C3EEEC9F92C5464CD0FAAA13 /* race.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = race.m; path = Sources/race.m; sourceTree = "<group>"; };
+		73AACAB60C21E8887475CF5FF0D76C5E /* secp256k1_ios-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "secp256k1_ios-umbrella.h"; sourceTree = "<group>"; };
+		73DA0DBD3D421C8A8A93C2F517ED6B48 /* scalar_4x64_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_4x64_impl.h; path = secp256k1_ios/src/scalar_4x64_impl.h; sourceTree = "<group>"; };
 		753650BD30E7808C6C6AE26719790145 /* Pods-VcCrypto.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VcCrypto.release.xcconfig"; sourceTree = "<group>"; };
 		75C18A0502EDB790D1E6C8C90918E883 /* Pods-VcNetworking.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VcNetworking.debug.xcconfig"; sourceTree = "<group>"; };
-		75FD3CD25D90F4DD1F4FE54AF362269C /* hash.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = hash.h; path = src/hash.h; sourceTree = "<group>"; };
-		766F71A777BA671115D8917E39170A1C /* scalar_low_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_low_impl.h; path = src/scalar_low_impl.h; sourceTree = "<group>"; };
+		786D51C7D2122FE69C614EC855704160 /* PromiseKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PromiseKit-dummy.m"; sourceTree = "<group>"; };
 		786FCD9A3ADF8E2137058AC66DE66545 /* Pods-VcNetworking-VcNetworkingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VcNetworking-VcNetworkingTests.release.xcconfig"; sourceTree = "<group>"; };
+		797B7243FC6C7A8F94A8CFA9E05C458C /* secp256k1_ios.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = secp256k1_ios.framework; path = secp256k1_ios.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7A0A196DDAC0BB85EE15E8319C4D3379 /* Pods-VcCrypto-VcCryptoTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VcCrypto-VcCryptoTests-dummy.m"; sourceTree = "<group>"; };
+		7A0FE94A2A17EC2649755A1A87228694 /* UIView+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIView+Promise.swift"; path = "Extensions/UIKit/Sources/UIView+Promise.swift"; sourceTree = "<group>"; };
 		7ABDBB05E52C4DF4FA90B40A6E1B79B6 /* Pods-VcCrypto-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VcCrypto-acknowledgements.plist"; sourceTree = "<group>"; };
-		7BD6427B65B29CB645F2D07E45B3661B /* PromiseKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PromiseKit-prefix.pch"; sourceTree = "<group>"; };
-		7CB299F3A6210695F1FD309BAA9AEF75 /* num_gmp.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num_gmp.h; path = src/num_gmp.h; sourceTree = "<group>"; };
+		7B20DE0D50C31BFF7CD0CC638E73A030 /* hash.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = hash.h; path = secp256k1_ios/src/hash.h; sourceTree = "<group>"; };
+		7C65CC0177A8C20AED52EEEA3B2271AC /* NSNotificationCenter+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNotificationCenter+AnyPromise.h"; path = "Extensions/Foundation/Sources/NSNotificationCenter+AnyPromise.h"; sourceTree = "<group>"; };
+		7D9E0A291B69EAF8057416D377913C49 /* UIView+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView+AnyPromise.m"; path = "Extensions/UIKit/Sources/UIView+AnyPromise.m"; sourceTree = "<group>"; };
 		7E6FEE58FA12102004378D11CF68B285 /* Pods-VcCrypto-VcCryptoTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VcCrypto-VcCryptoTests-Info.plist"; sourceTree = "<group>"; };
-		82755C006283793A77E1BD87508560F5 /* scalar_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_impl.h; path = src/scalar_impl.h; sourceTree = "<group>"; };
-		83F23CE50D886D9A1B3543CEA92E86BA /* PromiseKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = PromiseKit.modulemap; sourceTree = "<group>"; };
+		8536E2C3428FEC0CBC83BA96D7B1F178 /* fwd.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = fwd.h; path = Sources/fwd.h; sourceTree = "<group>"; };
 		866DE4B5D8B51608BF7AE4E651BC9DDB /* Pods-VcNetworking-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VcNetworking-acknowledgements.plist"; sourceTree = "<group>"; };
 		86A09FEBE88EA313AAD9DB9CC2B3B5C8 /* Pods-sdk-sdkTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-sdk-sdkTests.debug.xcconfig"; sourceTree = "<group>"; };
-		8AA69F9C9527192D189D7D5780F7C574 /* num_gmp_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num_gmp_impl.h; path = src/num_gmp_impl.h; sourceTree = "<group>"; };
-		8B494C053D2E4BB1066CA1D24EB1AD6D /* num.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num.h; path = src/num.h; sourceTree = "<group>"; };
-		8E073F32B53B1BF948756FC0C654B624 /* NSURLSession+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLSession+AnyPromise.h"; path = "Extensions/Foundation/Sources/NSURLSession+AnyPromise.h"; sourceTree = "<group>"; };
-		905C59B04706BE9C024D4C97CC37616D /* after.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = after.m; path = Sources/after.m; sourceTree = "<group>"; };
+		8B8AA9E8AFD6D1E00286A07C4AB350D8 /* scalar_8x32.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_8x32.h; path = secp256k1_ios/src/scalar_8x32.h; sourceTree = "<group>"; };
 		90964C2E4C18D68458ABB4D28380E1A8 /* Pods-VcNetworking-VcNetworkingTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VcNetworking-VcNetworkingTests-acknowledgements.plist"; sourceTree = "<group>"; };
-		9118411113C8AC271ADBD729F3A08037 /* secp256k1_recovery.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1_recovery.h; path = include/secp256k1_recovery.h; sourceTree = "<group>"; };
+		90F2E32C2C79B160376BBBA102BC4931 /* when.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = when.m; path = Sources/when.m; sourceTree = "<group>"; };
 		913633A108801D42AFF90C79E0A7F1A7 /* Pods-sdk-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-sdk-acknowledgements.markdown"; sourceTree = "<group>"; };
 		91C3B62A44E84117DD374F1F5E964BAF /* Pods-sdk-sdkTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-sdk-sdkTests.modulemap"; sourceTree = "<group>"; };
 		926DFDA3FD72FB3DE287F706A3AAF6AA /* Pods_VcCrypto_VcCryptoTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VcCrypto_VcCryptoTests.framework; path = "Pods-VcCrypto-VcCryptoTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		938B36D96A3F24AA449046C0753CAD45 /* ecmult_const_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_const_impl.h; path = src/ecmult_const_impl.h; sourceTree = "<group>"; };
+		9341A118F888C938C6A921D4C480EF20 /* ecmult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult.h; path = secp256k1_ios/src/ecmult.h; sourceTree = "<group>"; };
 		95ADB8E4CAD8828B1BF6FB48F33CF488 /* Pods-VcNetworking-VcNetworkingTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VcNetworking-VcNetworkingTests-umbrella.h"; sourceTree = "<group>"; };
+		963CB0AA85418F81F9A57689163ACD89 /* lax_der_parsing.c */ = {isa = PBXFileReference; includeInIndex = 1; name = lax_der_parsing.c; path = secp256k1_ios/contrib/lax_der_parsing.c; sourceTree = "<group>"; };
+		96E61770C0AF5A531C4B9A50F318CFEB /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Configuration.swift; path = Sources/Configuration.swift; sourceTree = "<group>"; };
+		97DE9991CD4766CCF7DFD839AC848D4B /* firstly.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = firstly.swift; path = Sources/firstly.swift; sourceTree = "<group>"; };
 		97E9BF75B7C96020D9EA2A2C8A8DB080 /* Pods-sdk-sdkTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-sdk-sdkTests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		98D8EAE390CEF961B0370289A947A522 /* PMKUIKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PMKUIKit.h; path = Extensions/UIKit/Sources/PMKUIKit.h; sourceTree = "<group>"; };
-		993A7754E6301C70093F3E92A5D0FDC4 /* bitcoin-core-secp256k1.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "bitcoin-core-secp256k1.modulemap"; sourceTree = "<group>"; };
+		9839460CCEC6354E3D6F4B1D9A9EA615 /* VcCrypto.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = VcCrypto.debug.xcconfig; sourceTree = "<group>"; };
+		9BB7072EC80533A9DB4161D418152882 /* secp256k1_ecdh.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1_ecdh.h; path = secp256k1_ios/include/secp256k1_ecdh.h; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		9DD4500D2B1C260833A564AA518A3283 /* NSURLSession+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSURLSession+Promise.swift"; path = "Extensions/Foundation/Sources/NSURLSession+Promise.swift"; sourceTree = "<group>"; };
-		9F7E6155D9D0C1F05D36EF36221BEDAB /* scalar_4x64_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_4x64_impl.h; path = src/scalar_4x64_impl.h; sourceTree = "<group>"; };
-		9FFFD33A919760ADE3176D92B725531C /* AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AnyPromise.m; path = Sources/AnyPromise.m; sourceTree = "<group>"; };
 		A00718971BF6B79CB0FCE8CE323A6E05 /* Pods-VcJwt-VcJwtTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VcJwt-VcJwtTests-frameworks.sh"; sourceTree = "<group>"; };
-		A02DE9E74DEB9A256A9F457666C21E46 /* main_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = main_impl.h; path = src/modules/ecdh/main_impl.h; sourceTree = "<group>"; };
+		A02ACE07DAF9653C72C85571C867DAF5 /* NSURLSession+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSURLSession+AnyPromise.m"; path = "Extensions/Foundation/Sources/NSURLSession+AnyPromise.m"; sourceTree = "<group>"; };
+		A0AE03803CB1B486BF7739D28DE295C1 /* ecmult_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_impl.h; path = secp256k1_ios/src/ecmult_impl.h; sourceTree = "<group>"; };
 		A1477CF5E82E4955EE595485E7BF1807 /* Pods_VcCrypto.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VcCrypto.framework; path = "Pods-VcCrypto.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1AA70E6D12FFBA5ACB814A890F6BE10 /* Pods-sdk-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-sdk-Info.plist"; sourceTree = "<group>"; };
-		A35A5A64A2BA545E671773BE11179C05 /* PromiseKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PromiseKit.h; path = Sources/PromiseKit.h; sourceTree = "<group>"; };
-		A35BC4349E1FD5846C567D70FCFF0AC4 /* Guarantee.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Guarantee.swift; path = Sources/Guarantee.swift; sourceTree = "<group>"; };
-		A3FBB9478AAA18A15E7DBABBCEBC01FD /* group.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = group.h; path = src/group.h; sourceTree = "<group>"; };
-		A5C6B94622B196AE1DE59D3276DE73D5 /* Resolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Resolver.swift; path = Sources/Resolver.swift; sourceTree = "<group>"; };
+		A2EA213B48DC28B4037837BDC7410D0C /* dispatch_promise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = dispatch_promise.m; path = Sources/dispatch_promise.m; sourceTree = "<group>"; };
 		A5FABFD3DF1528E7F959C40B23727338 /* Pods-VcCrypto-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VcCrypto-umbrella.h"; sourceTree = "<group>"; };
-		A74FF48648B65F4D615783FBB96091AA /* bitcoin-core-secp256k1-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "bitcoin-core-secp256k1-dummy.m"; sourceTree = "<group>"; };
-		A80D7C75CDCD587F23CC29B3B1A72D21 /* UIView+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIView+Promise.swift"; path = "Extensions/UIKit/Sources/UIView+Promise.swift"; sourceTree = "<group>"; };
+		A62A210C649AF5DFF8193A3D6CF19B15 /* NSNotificationCenter+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSNotificationCenter+Promise.swift"; path = "Extensions/Foundation/Sources/NSNotificationCenter+Promise.swift"; sourceTree = "<group>"; };
+		A687BD5D47AAA0C72FE790A90D841E5D /* scalar_low.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_low.h; path = secp256k1_ios/src/scalar_low.h; sourceTree = "<group>"; };
 		A9D37953BC7E8DB814B7F81CB859304E /* Pods-sdk.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-sdk.release.xcconfig"; sourceTree = "<group>"; };
-		AAC754938C9FB23E1FEF34D5F307D640 /* CustomStringConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomStringConvertible.swift; path = Sources/CustomStringConvertible.swift; sourceTree = "<group>"; };
-		ABBA28790FD69DCD34B262FA4794D03E /* Box.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Box.swift; path = Sources/Box.swift; sourceTree = "<group>"; };
-		AC39F1E8A5A681B26E9B512F3B2C90FB /* AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AnyPromise.h; path = Sources/AnyPromise.h; sourceTree = "<group>"; };
+		AA70392775FC09CA0A5566C942B2D5D7 /* field.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field.h; path = secp256k1_ios/src/field.h; sourceTree = "<group>"; };
+		AB7EDE0742AFF5F3232CDA094EB7A124 /* field_5x52.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52.h; path = secp256k1_ios/src/field_5x52.h; sourceTree = "<group>"; };
 		AFA6A86EEA135B7D3F886F3C367CB024 /* Pods-VcNetworking-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VcNetworking-acknowledgements.markdown"; sourceTree = "<group>"; };
 		AFF5CD2D03E16F1C71B411987B4702B2 /* Pods-VcCrypto.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VcCrypto.modulemap"; sourceTree = "<group>"; };
-		B0108C8CDA1A868A4984037EA9ABC4AE /* VcCrypto.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = VcCrypto.xcconfig; sourceTree = "<group>"; };
-		B26A56E3B8F06F12A9276D5074A5B4A7 /* NSObject+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSObject+Promise.swift"; path = "Extensions/Foundation/Sources/NSObject+Promise.swift"; sourceTree = "<group>"; };
-		B6A9E8F5AA16BDB7CA095B0B132DF844 /* field_10x26_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_10x26_impl.h; path = src/field_10x26_impl.h; sourceTree = "<group>"; };
+		B2EFEE9B9328F545CE210D88B3810EC8 /* NSObject+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSObject+Promise.swift"; path = "Extensions/Foundation/Sources/NSObject+Promise.swift"; sourceTree = "<group>"; };
+		B3CE95F3C13990139072A473BAA550A7 /* NSNotificationCenter+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNotificationCenter+AnyPromise.m"; path = "Extensions/Foundation/Sources/NSNotificationCenter+AnyPromise.m"; sourceTree = "<group>"; };
+		B53A53BC4C3747A456F98302861613D4 /* VcCrypto.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = VcCrypto.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		B59C04F48A9014381511F9623105A875 /* PromiseKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PromiseKit.debug.xcconfig; sourceTree = "<group>"; };
+		B683C4D0E6E23E3F79339391D128B996 /* PMKFoundation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PMKFoundation.h; path = Extensions/Foundation/Sources/PMKFoundation.h; sourceTree = "<group>"; };
 		B6EC27AA2CAA5B28A8C123E4E8A03D79 /* Pods-VcJwt-VcJwtTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VcJwt-VcJwtTests.release.xcconfig"; sourceTree = "<group>"; };
 		B6F641AC9D36AFA04BBDE7CA161E6774 /* Pods-VcNetworking-VcNetworkingTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VcNetworking-VcNetworkingTests.modulemap"; sourceTree = "<group>"; };
 		B74D3DB6DE612165421881E6A3A45B09 /* Pods-VcJwt-VcJwtTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VcJwt-VcJwtTests-Info.plist"; sourceTree = "<group>"; };
 		B7F2AA41A756CDA0AC92E8408C038C42 /* Pods-sdk-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-sdk-umbrella.h"; sourceTree = "<group>"; };
 		B86999909745D8DAC7F3CBF6A9395EE7 /* Pods-VcNetworking-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VcNetworking-umbrella.h"; sourceTree = "<group>"; };
-		B8CDE7E03F7FFBAB8AEF76950B03A3DB /* when.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = when.m; path = Sources/when.m; sourceTree = "<group>"; };
+		B9F2029FCF6C147890BBFA918230D1D3 /* main_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = main_impl.h; path = secp256k1_ios/src/modules/ecdh/main_impl.h; sourceTree = "<group>"; };
 		BB8DECD5EB000E08B56619F628A2D96F /* Pods-VcJwt-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VcJwt-umbrella.h"; sourceTree = "<group>"; };
-		BBF5A6FC4E52452C68782CE2F701BA4D /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Error.swift; path = Sources/Error.swift; sourceTree = "<group>"; };
-		BC57494B77FCC93ACACB308CF9E3631C /* secp256k1_ecdh.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1_ecdh.h; path = include/secp256k1_ecdh.h; sourceTree = "<group>"; };
+		BBA5160D4602B02FC6AA8B82A7071A13 /* secp256k1_ios.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = secp256k1_ios.modulemap; sourceTree = "<group>"; };
 		BC5C56C8F1257CAAD0DA3ED3E53BA63F /* Pods-VcCrypto-VcCryptoTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VcCrypto-VcCryptoTests-frameworks.sh"; sourceTree = "<group>"; };
+		BC78C53213A88D95B49A8F6B925B1555 /* when.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = when.swift; path = Sources/when.swift; sourceTree = "<group>"; };
 		BCAE1ACCD373486B15D30B70E901B61D /* Pods-sdk-sdkTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-sdk-sdkTests-Info.plist"; sourceTree = "<group>"; };
+		BCFF8CAACC2DE737E452F090CF9E6254 /* scratch.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scratch.h; path = secp256k1_ios/src/scratch.h; sourceTree = "<group>"; };
+		BFB01212F7A6B19DC6A3E26AFC4ACF2C /* CustomStringConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomStringConvertible.swift; path = Sources/CustomStringConvertible.swift; sourceTree = "<group>"; };
 		BFBCC8896FC7CC012C3622387DCDD9D4 /* Pods-VcCrypto-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VcCrypto-dummy.m"; sourceTree = "<group>"; };
-		C00AA9B85AE0296B38EE49F201668070 /* Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Promise.swift; path = Sources/Promise.swift; sourceTree = "<group>"; };
+		BFDAFDA15AC40DE93C97A4D5D27D7A74 /* eckey_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = eckey_impl.h; path = secp256k1_ios/src/eckey_impl.h; sourceTree = "<group>"; };
+		C09DCCEB46C85236A4B46E628D6C20E2 /* VcNetworking.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = VcNetworking.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		C0CC4441F818499CA22F18AF8BEBA978 /* NSTask+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSTask+AnyPromise.m"; path = "Extensions/Foundation/Sources/NSTask+AnyPromise.m"; sourceTree = "<group>"; };
 		C12A084838426886105BA4275B30295B /* Pods_VcNetworking_VcNetworkingTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VcNetworking_VcNetworkingTests.framework; path = "Pods-VcNetworking-VcNetworkingTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C26428FE936F8E44D28B7EF6EF32A837 /* hash_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = hash_impl.h; path = secp256k1_ios/src/hash_impl.h; sourceTree = "<group>"; };
+		C31433B9FC270C8D03B007BF97EA5C22 /* secp256k1_ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = secp256k1_ios.release.xcconfig; sourceTree = "<group>"; };
+		C3B1986B76BE8BFA1F47E63519975F7A /* UIViewPropertyAnimator+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIViewPropertyAnimator+Promise.swift"; path = "Extensions/UIKit/Sources/UIViewPropertyAnimator+Promise.swift"; sourceTree = "<group>"; };
 		C47EB4944C05375F2E3EEA2A0D948008 /* Pods-VcJwt-VcJwtTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VcJwt-VcJwtTests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		C48992D9CBCA6B51CA670EF1C5643EB4 /* Pods-VcNetworking.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VcNetworking.modulemap"; sourceTree = "<group>"; };
-		C61EEAA77AC36DB5F3679E2891202A98 /* scratch.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scratch.h; path = src/scratch.h; sourceTree = "<group>"; };
-		CA31378D72B1854484A3AE24090C9E23 /* firstly.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = firstly.swift; path = Sources/firstly.swift; sourceTree = "<group>"; };
+		C865F5F867FCB991FC50CA9687D105F2 /* num_gmp.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num_gmp.h; path = secp256k1_ios/src/num_gmp.h; sourceTree = "<group>"; };
 		CA5338110A0860CDDD771C68CED55767 /* Pods-VcJwt-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VcJwt-dummy.m"; sourceTree = "<group>"; };
+		CAFEE0F74E0C9294EB8B6D4566B5914C /* afterlife.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = afterlife.swift; path = Extensions/Foundation/Sources/afterlife.swift; sourceTree = "<group>"; };
+		CB8C9C6F8211787F2948D4A834A63619 /* VcNetworking.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = VcNetworking.release.xcconfig; sourceTree = "<group>"; };
 		CB911877D1551E93C92A6A68217C8C2D /* Pods-VcJwt-VcJwtTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VcJwt-VcJwtTests.modulemap"; sourceTree = "<group>"; };
-		CBC4F120CE3B9E5CA8EB2AA34432C51E /* PromiseKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PromiseKit.xcconfig; sourceTree = "<group>"; };
-		CC69D6B91ABDC771DF760185F03CAE94 /* VcNetworking.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = VcNetworking.xcconfig; sourceTree = "<group>"; };
-		D04597055A1A7A7F198D489FFEA7C893 /* race.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = race.swift; path = Sources/race.swift; sourceTree = "<group>"; };
-		D170FB93A9659AC62EB96EEFBD07F89A /* Catchable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Catchable.swift; path = Sources/Catchable.swift; sourceTree = "<group>"; };
-		D1E76143A41D6054F67BAD6B914A4788 /* UIViewPropertyAnimator+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIViewPropertyAnimator+Promise.swift"; path = "Extensions/UIKit/Sources/UIViewPropertyAnimator+Promise.swift"; sourceTree = "<group>"; };
+		CCDD9EEB414D58596A027510BAC84C0D /* PromiseKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PromiseKit-prefix.pch"; sourceTree = "<group>"; };
+		CD4D03B1A375066A4DB77D0E462E918D /* scratch_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scratch_impl.h; path = secp256k1_ios/src/scratch_impl.h; sourceTree = "<group>"; };
+		D000FD533E4085400D819CE04E649689 /* lax_der_privatekey_parsing.c */ = {isa = PBXFileReference; includeInIndex = 1; name = lax_der_privatekey_parsing.c; path = secp256k1_ios/contrib/lax_der_privatekey_parsing.c; sourceTree = "<group>"; };
 		D35BB3B3B48DD42C332B5CB4CBFAD62E /* Pods-VcCrypto-VcCryptoTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VcCrypto-VcCryptoTests.modulemap"; sourceTree = "<group>"; };
-		D47943C7EA6F97F2323EC971B75DEE8B /* field_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_impl.h; path = src/field_impl.h; sourceTree = "<group>"; };
-		D4C549A9D2D3EADF98D88710605C195C /* secp256k1_preallocated.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1_preallocated.h; path = include/secp256k1_preallocated.h; sourceTree = "<group>"; };
+		D4A74638C4ED8D0224F351F76E29991A /* scalar_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_impl.h; path = secp256k1_ios/src/scalar_impl.h; sourceTree = "<group>"; };
 		D5152B7075303678C6AB06666659C2F4 /* Pods-VcNetworking-VcNetworkingTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VcNetworking-VcNetworkingTests-frameworks.sh"; sourceTree = "<group>"; };
-		D62F2EFA7AB63909208572E68F4BB8E3 /* secp256k1.c */ = {isa = PBXFileReference; includeInIndex = 1; name = secp256k1.c; path = src/secp256k1.c; sourceTree = "<group>"; };
+		D6E557CC48D00AA85F709DBA6037FBC2 /* Process+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Process+Promise.swift"; path = "Extensions/Foundation/Sources/Process+Promise.swift"; sourceTree = "<group>"; };
+		D727184A6E2EA9D853BA156FB0E2DD05 /* ecdsa.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecdsa.h; path = secp256k1_ios/src/ecdsa.h; sourceTree = "<group>"; };
 		DA35576EF1835E96B3BAAF86A6863E83 /* Pods-VcNetworking-VcNetworkingTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VcNetworking-VcNetworkingTests-dummy.m"; sourceTree = "<group>"; };
 		DC1A8979053D9CEF9AC5A00E418B4BCA /* Pods-VcCrypto-VcCryptoTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VcCrypto-VcCryptoTests-umbrella.h"; sourceTree = "<group>"; };
-		DD1B990AF95F4DBE8672AC21882386C3 /* UIViewController+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIViewController+AnyPromise.h"; path = "Extensions/UIKit/Sources/UIViewController+AnyPromise.h"; sourceTree = "<group>"; };
-		DE99681D72B645575A3B31F1878B6B3E /* scalar_low.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_low.h; path = src/scalar_low.h; sourceTree = "<group>"; };
-		E3751E48F6AC11A7D6A7189470F35481 /* bitcoin-core-secp256k1.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "bitcoin-core-secp256k1.xcconfig"; sourceTree = "<group>"; };
-		E586CD62595B6116F796EC6D4087F32F /* afterlife.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = afterlife.swift; path = Extensions/Foundation/Sources/afterlife.swift; sourceTree = "<group>"; };
-		E5C06A45625F17E4E194C69314E4A145 /* NSNotificationCenter+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNotificationCenter+AnyPromise.h"; path = "Extensions/Foundation/Sources/NSNotificationCenter+AnyPromise.h"; sourceTree = "<group>"; };
+		DD76667382B20B88BB8935E1812CE344 /* ecmult_gen.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_gen.h; path = secp256k1_ios/src/ecmult_gen.h; sourceTree = "<group>"; };
+		DE6FA170EC3BDE6DB448239C1942BD6C /* secp256k1_ios-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "secp256k1_ios-dummy.m"; sourceTree = "<group>"; };
+		E28FE3E8C393FA4C5D3C55E303F6643E /* Box.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Box.swift; path = Sources/Box.swift; sourceTree = "<group>"; };
+		E2CB2ADA690E2910241611766C32E2F3 /* hang.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = hang.swift; path = Sources/hang.swift; sourceTree = "<group>"; };
+		E4321D605DC983B72C2F14B9F58BA5E8 /* secp256k1.c */ = {isa = PBXFileReference; includeInIndex = 1; name = secp256k1.c; path = secp256k1_ios/src/secp256k1.c; sourceTree = "<group>"; };
+		E524558EF7B0FA2C58EDD5F2A6B8ACF5 /* field_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_impl.h; path = secp256k1_ios/src/field_impl.h; sourceTree = "<group>"; };
 		E64D0CF3AEDBD5F63E93B6B1DA0B42CC /* Pods-sdk-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-sdk-acknowledgements.plist"; sourceTree = "<group>"; };
-		E71384D1B500AB043FF90A3C77E5501A /* UIView+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView+AnyPromise.m"; path = "Extensions/UIKit/Sources/UIView+AnyPromise.m"; sourceTree = "<group>"; };
-		E76431A8C01E16FB984BC641B1482EAA /* UIView+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIView+AnyPromise.h"; path = "Extensions/UIKit/Sources/UIView+AnyPromise.h"; sourceTree = "<group>"; };
-		E9620E1C596E2E47F3B680F788369306 /* field_10x26.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_10x26.h; path = src/field_10x26.h; sourceTree = "<group>"; };
-		E99BF2586AEB072F8DB1E6B6BDDF8F4C /* NSNotificationCenter+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSNotificationCenter+Promise.swift"; path = "Extensions/Foundation/Sources/NSNotificationCenter+Promise.swift"; sourceTree = "<group>"; };
-		EAF1187BC13645A12EACBF172AAA963B /* num_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num_impl.h; path = src/num_impl.h; sourceTree = "<group>"; };
+		E73D5A57C8F50B074932D85A899DCD0C /* group.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = group.h; path = secp256k1_ios/src/group.h; sourceTree = "<group>"; };
+		E7DA78A45CEFDA2BD66E6E5BD437B1B9 /* ecdsa_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecdsa_impl.h; path = secp256k1_ios/src/ecdsa_impl.h; sourceTree = "<group>"; };
+		E80CBCCF2CEE58DD6AA7B3689BD17DA6 /* lax_der_privatekey_parsing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = lax_der_privatekey_parsing.h; path = secp256k1_ios/contrib/lax_der_privatekey_parsing.h; sourceTree = "<group>"; };
+		E881A39F7EEB33AD66E34B200A5476EC /* scalar_8x32_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_8x32_impl.h; path = secp256k1_ios/src/scalar_8x32_impl.h; sourceTree = "<group>"; };
+		E904D2F45316FC04196883E3BED455A8 /* main_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = main_impl.h; path = secp256k1_ios/src/modules/recovery/main_impl.h; sourceTree = "<group>"; };
+		E96E0F7600B891D2D2D4C7B9138C1B0B /* AnyPromise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnyPromise.swift; path = Sources/AnyPromise.swift; sourceTree = "<group>"; };
+		EB522A7F729177C33D085ABD72CA65F6 /* PromiseKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PromiseKit.h; path = Sources/PromiseKit.h; sourceTree = "<group>"; };
 		ECF647F9FA7A25AEB7A9E65F7BEAC508 /* Pods_VcJwt_VcJwtTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VcJwt_VcJwtTests.framework; path = "Pods-VcJwt-VcJwtTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		EEC3F3EDA395D7520424BD541862AA16 /* field.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field.h; path = src/field.h; sourceTree = "<group>"; };
-		EFC04EF6E845E7832336EF1B12AC9E04 /* Thenable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Thenable.swift; path = Sources/Thenable.swift; sourceTree = "<group>"; };
+		F00A8F673B90C211CDFBFDF738DFBF27 /* field_5x52_int128_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52_int128_impl.h; path = secp256k1_ios/src/field_5x52_int128_impl.h; sourceTree = "<group>"; };
+		F01F930C93559DD4B9F420D5D237E6C9 /* LogEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LogEvent.swift; path = Sources/LogEvent.swift; sourceTree = "<group>"; };
 		F13AFB3D359111DDB86C0E51C653640F /* Pods-VcJwt.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VcJwt.modulemap"; sourceTree = "<group>"; };
 		F37EDB0E21047DD31A051CC54A1C2E28 /* Pods-VcNetworking-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VcNetworking-dummy.m"; sourceTree = "<group>"; };
-		F49BCF208D11EE478A05AAF9800A7E31 /* Deprecations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Deprecations.swift; path = Sources/Deprecations.swift; sourceTree = "<group>"; };
-		F4BD4022F180C944F0C037A0C4C719A3 /* eckey.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = eckey.h; path = src/eckey.h; sourceTree = "<group>"; };
-		F4F6E5B27BB5CB6B4D2846DDF1A5F3CC /* AnyPromise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnyPromise.swift; path = Sources/AnyPromise.swift; sourceTree = "<group>"; };
-		F5D86CAF969ABF249E5F44E80F70D6FC /* ecdsa_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecdsa_impl.h; path = src/ecdsa_impl.h; sourceTree = "<group>"; };
-		F673C693801031932449D23955759008 /* after.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = after.swift; path = Sources/after.swift; sourceTree = "<group>"; };
-		F67418A4C5BB88BB468E0B60C5FA963E /* main_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = main_impl.h; path = src/modules/recovery/main_impl.h; sourceTree = "<group>"; };
-		FBA66929FE4491B4DC0CF67A2ADAC42E /* ecmult_const.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_const.h; path = src/ecmult_const.h; sourceTree = "<group>"; };
-		FFDB7DCF590CA80CF4976FF708447B59 /* assumptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = assumptions.h; path = src/assumptions.h; sourceTree = "<group>"; };
-		FFE9610DD10C3F32371E4BD06B2F25A5 /* hang.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = hang.swift; path = Sources/hang.swift; sourceTree = "<group>"; };
+		F3C317F718A42143149D0B6A88B56DCD /* VcNetworking.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = VcNetworking.debug.xcconfig; sourceTree = "<group>"; };
+		F83A99AE3895216765C532D36951A1D2 /* UIView+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIView+AnyPromise.h"; path = "Extensions/UIKit/Sources/UIView+AnyPromise.h"; sourceTree = "<group>"; };
+		FAE13A4D4D22D7C0B347EE84F1E24B3B /* secp256k1_ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = secp256k1_ios.debug.xcconfig; sourceTree = "<group>"; };
+		FC4E9889F9E1F402C3DB2B3A90676C11 /* lax_der_parsing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = lax_der_parsing.h; path = secp256k1_ios/contrib/lax_der_parsing.h; sourceTree = "<group>"; };
+		FFDD3C629AC54926AD39A2158000BCFD /* scalar_low_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_low_impl.h; path = secp256k1_ios/src/scalar_low_impl.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		37F7DC58A16DA323FF0952745A9AFA03 /* Frameworks */ = {
+		2C83921CDECA3C271821203C7E186A64 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				237648C7A378710FBF60DD8FA89328F9 /* Foundation.framework in Frameworks */,
+				439E8938301084A4BDF09CFEC5D4BC6A /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2D3C8995638500657B8B348A32619168 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4507D6A4F46570721A12B3C062825DCC /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -579,97 +486,65 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4EAAD77126A1982C6A4BD14B4580C28F /* Frameworks */ = {
+		49D2371319A8B7923527818F828B4D45 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A9CE6C7080FBCD19569BF940188C2F39 /* Foundation.framework in Frameworks */,
+				BAA5F14DE796A70EDCD10338993AB66E /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5A50570BF1FD18F4D708F508E7DC294E /* Frameworks */ = {
+		9193E9874821A4B26091052545651CCD /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				301A2994622F71810829C83C3B5C6E63 /* Foundation.framework in Frameworks */,
+				CB3829655DEDB456332BABDF0E59CEAA /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6C247BA6765E272940925E2B84DD477A /* Frameworks */ = {
+		9D6580D46BB902ECDC53238223D21ACD /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C47AE531A5D2A2399277ED4320A5D11F /* Foundation.framework in Frameworks */,
+				DA9B0143EAEDB56BF439C761C55C87F8 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		94844C1F324432769564EF25E89B8E59 /* Frameworks */ = {
+		AD45CFCF809EB9F6843E288CD0E119CB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CDD6E93A8AC6AAF9B5B601C91FCD9ABA /* Foundation.framework in Frameworks */,
+				CDB8859DB8D7A7AEB3CDA3AC896800BB /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		99FDB285877F506D947D169C372A3FE3 /* Frameworks */ = {
+		B61D2F9C8FFBC67131695BF5653EF7F9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B19B894D15BBB62C233BA2E09294369B /* Foundation.framework in Frameworks */,
+				7C48EB94DC67F324F6B94CA5E597AA8F /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BEAE199313ADB2B68B7CF51BFEB1B909 /* Frameworks */ = {
+		B8ED4F7B27BFC5BBB5EFC5E24588A1D5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3BA19753292E7D3672BCD0ECB28AF69C /* Foundation.framework in Frameworks */,
+				2E35C2C7D151A14B1A25D04DBCB6519A /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E59279D098079C0286CCB84D7B5F85A2 /* Frameworks */ = {
+		DDC0CF0145273198FF86FD87F2F3FA18 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FCD66010C23D87F9B0E1EF2A7270A3BB /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FD4372A1FEE3A3252A8B4C3902B46746 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F2750E1A31C27E20517AF6016EA3FE8B /* Foundation.framework in Frameworks */,
+				7E91AAB4DD22F6D1623C458D27E430D2 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		01B1B9A752823C1B9A345DFAEDFCBD04 /* VcNetworking */ = {
-			isa = PBXGroup;
-			children = (
-				4B3276AC0047202E71F9009756E96E73 /* Pod */,
-				89F6A3C12F2054F88294995F1C6C8E22 /* Support Files */,
-			);
-			name = VcNetworking;
-			path = ../../VcNetworking;
-			sourceTree = "<group>";
-		};
-		0E0C12D7132DA6D63F482C72F4E2210C /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				83F23CE50D886D9A1B3543CEA92E86BA /* PromiseKit.modulemap */,
-				CBC4F120CE3B9E5CA8EB2AA34432C51E /* PromiseKit.xcconfig */,
-				3B28B2A2E81B13D1C160294EBE8DA74D /* PromiseKit-dummy.m */,
-				18A1EBCA4C05FA2B762860A43B9F655E /* PromiseKit-Info.plist */,
-				7BD6427B65B29CB645F2D07E45B3661B /* PromiseKit-prefix.pch */,
-				6CC0E54668B48A9784A91C016F12FED0 /* PromiseKit-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/PromiseKit";
-			sourceTree = "<group>";
-		};
 		0F2351711728AB0CFC9FB06F509BABD7 /* Pods-VcNetworking-VcNetworkingTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -704,6 +579,16 @@
 			path = "Target Support Files/Pods-VcJwt-VcJwtTests";
 			sourceTree = "<group>";
 		};
+		14FBAFC262E316645748919951E836F7 /* VcCrypto */ = {
+			isa = PBXGroup;
+			children = (
+				804D474517D21DBB7650275EAF52B0B7 /* Pod */,
+				225C66C3750E86DE159523FBC890C7A4 /* Support Files */,
+			);
+			name = VcCrypto;
+			path = ../../VcCrypto;
+			sourceTree = "<group>";
+		};
 		1628BF05B4CAFDCC3549A101F5A10A17 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -712,11 +597,29 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		225C66C3750E86DE159523FBC890C7A4 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				9839460CCEC6354E3D6F4B1D9A9EA615 /* VcCrypto.debug.xcconfig */,
+				6CB79A2F18EFFE2B528DD29DE55DCC66 /* VcCrypto.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../sdk/Pods/Target Support Files/VcCrypto";
+			sourceTree = "<group>";
+		};
+		3D926DA2AE43467172CBB083C9F7C6E0 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				C09DCCEB46C85236A4B46E628D6C20E2 /* VcNetworking.podspec */,
+			);
+			name = Pod;
+			sourceTree = "<group>";
+		};
 		3EC135C71EFECC181A0DD6C8F076345A /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				628136FF256D5A7BCE7005A02E912F16 /* VcCrypto */,
-				01B1B9A752823C1B9A345DFAEDFCBD04 /* VcNetworking */,
+				14FBAFC262E316645748919951E836F7 /* VcCrypto */,
+				53FBCB9D75A69D1CE8B64D70FF0C8A0A /* VcNetworking */,
 			);
 			name = "Development Pods";
 			sourceTree = "<group>";
@@ -737,30 +640,24 @@
 			path = "Target Support Files/Pods-VcCrypto";
 			sourceTree = "<group>";
 		};
-		470E18A0DCB23DA2D7B4BCC1B608C139 /* Pods */ = {
+		4C0743E6FDD785CDEC0F77431EED4953 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				B9C25F747B075FFE207E82D3D005768F /* bitcoin-core-secp256k1 */,
-				80B78CE8897ADDCD57278702C0B8F873 /* PromiseKit */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		4B3276AC0047202E71F9009756E96E73 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				0835F553980ECBAC01CDB6FB67646096 /* VcNetworking.podspec */,
-			);
-			name = Pod;
-			sourceTree = "<group>";
-		};
-		58695EBD74B14EF101EBD090BDE4ED4F /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				B0108C8CDA1A868A4984037EA9ABC4AE /* VcCrypto.xcconfig */,
+				F3C317F718A42143149D0B6A88B56DCD /* VcNetworking.debug.xcconfig */,
+				CB8C9C6F8211787F2948D4A834A63619 /* VcNetworking.release.xcconfig */,
 			);
 			name = "Support Files";
-			path = "../sdk/Pods/Target Support Files/VcCrypto";
+			path = "../sdk/Pods/Target Support Files/VcNetworking";
+			sourceTree = "<group>";
+		};
+		53FBCB9D75A69D1CE8B64D70FF0C8A0A /* VcNetworking */ = {
+			isa = PBXGroup;
+			children = (
+				3D926DA2AE43467172CBB083C9F7C6E0 /* Pod */,
+				4C0743E6FDD785CDEC0F77431EED4953 /* Support Files */,
+			);
+			name = VcNetworking;
+			path = ../../VcNetworking;
 			sourceTree = "<group>";
 		};
 		5D8019271D98757F24ADDF5348B7EB11 /* Pods-VcNetworking */ = {
@@ -795,16 +692,6 @@
 			path = "Target Support Files/Pods-sdk";
 			sourceTree = "<group>";
 		};
-		628136FF256D5A7BCE7005A02E912F16 /* VcCrypto */ = {
-			isa = PBXGroup;
-			children = (
-				9E199CC8FC256BDE3D856C9E520C77ED /* Pod */,
-				58695EBD74B14EF101EBD090BDE4ED4F /* Support Files */,
-			);
-			name = VcCrypto;
-			path = ../../VcCrypto;
-			sourceTree = "<group>";
-		};
 		68C6CC9D04FA963A1BE29F34CE483A38 /* Pods-VcJwt */ = {
 			isa = PBXGroup;
 			children = (
@@ -821,78 +708,47 @@
 			path = "Target Support Files/Pods-VcJwt";
 			sourceTree = "<group>";
 		};
-		80B78CE8897ADDCD57278702C0B8F873 /* PromiseKit */ = {
+		6E4148D7DD83DDA70A8AA25F8E68C9E4 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				E52877076279A3791E562C74D0F999B5 /* CorePromise */,
-				CE0417C5E574E072BA699AE196741CA5 /* Foundation */,
-				0E0C12D7132DA6D63F482C72F4E2210C /* Support Files */,
-				929202DE3BF1EB03226FBBCE21DC3BAA /* UIKit */,
+				9716F0D45B6C41928078C0FA2277B15D /* PromiseKit */,
+				D46B219C9D179C29B17CC28550FA96E7 /* secp256k1_ios */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		804D474517D21DBB7650275EAF52B0B7 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				B53A53BC4C3747A456F98302861613D4 /* VcCrypto.podspec */,
+			);
+			name = Pod;
+			sourceTree = "<group>";
+		};
+		9716F0D45B6C41928078C0FA2277B15D /* PromiseKit */ = {
+			isa = PBXGroup;
+			children = (
+				A6C5B7473ED6E40457559B8FF80D3292 /* CorePromise */,
+				CDFF04ACF03A23404AB4A2AD57F39831 /* Foundation */,
+				B28154FAF874AD2D412BB56438F792A6 /* Support Files */,
+				9D1F8248E2420D3D6434111A7404C1D2 /* UIKit */,
 			);
 			name = PromiseKit;
 			path = PromiseKit;
 			sourceTree = "<group>";
 		};
-		89F6A3C12F2054F88294995F1C6C8E22 /* Support Files */ = {
+		9D1F8248E2420D3D6434111A7404C1D2 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
-				CC69D6B91ABDC771DF760185F03CAE94 /* VcNetworking.xcconfig */,
-			);
-			name = "Support Files";
-			path = "../sdk/Pods/Target Support Files/VcNetworking";
-			sourceTree = "<group>";
-		};
-		8CCD289A063E8649185814FD38A2177B /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				228C193C5D97130985D9AB568E3E7F86 /* bitcoin_core_secp256k1.framework */,
-				0421A70AF7B3109297422E3D8F394BAE /* Pods_sdk.framework */,
-				0894F527EF50033A03AB4F13D833DCE2 /* Pods_sdk_sdkTests.framework */,
-				A1477CF5E82E4955EE595485E7BF1807 /* Pods_VcCrypto.framework */,
-				926DFDA3FD72FB3DE287F706A3AAF6AA /* Pods_VcCrypto_VcCryptoTests.framework */,
-				2B5B93F38F19F3082CFD2F55752F335E /* Pods_VcJwt.framework */,
-				ECF647F9FA7A25AEB7A9E65F7BEAC508 /* Pods_VcJwt_VcJwtTests.framework */,
-				4AE0F0DFA89130C50F8620807B62715A /* Pods_VcNetworking.framework */,
-				C12A084838426886105BA4275B30295B /* Pods_VcNetworking_VcNetworkingTests.framework */,
-				002B1E88BA14EBF633CD66EBFBA107E9 /* PromiseKit.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		916CA7DF051F1A81297D56536920167C /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				993A7754E6301C70093F3E92A5D0FDC4 /* bitcoin-core-secp256k1.modulemap */,
-				E3751E48F6AC11A7D6A7189470F35481 /* bitcoin-core-secp256k1.xcconfig */,
-				A74FF48648B65F4D615783FBB96091AA /* bitcoin-core-secp256k1-dummy.m */,
-				31F2466A7E8D153CA95BF23E8513F91E /* bitcoin-core-secp256k1-Info.plist */,
-				41E581E84D52D93CC8F265CBF419028E /* bitcoin-core-secp256k1-prefix.pch */,
-				1769986EB7E8D241D2DD7CC4E6521A67 /* bitcoin-core-secp256k1-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/bitcoin-core-secp256k1";
-			sourceTree = "<group>";
-		};
-		929202DE3BF1EB03226FBBCE21DC3BAA /* UIKit */ = {
-			isa = PBXGroup;
-			children = (
-				98D8EAE390CEF961B0370289A947A522 /* PMKUIKit.h */,
-				E76431A8C01E16FB984BC641B1482EAA /* UIView+AnyPromise.h */,
-				E71384D1B500AB043FF90A3C77E5501A /* UIView+AnyPromise.m */,
-				A80D7C75CDCD587F23CC29B3B1A72D21 /* UIView+Promise.swift */,
-				DD1B990AF95F4DBE8672AC21882386C3 /* UIViewController+AnyPromise.h */,
-				36F921352F9288D40551163CBCE6FA1E /* UIViewController+AnyPromise.m */,
-				D1E76143A41D6054F67BAD6B914A4788 /* UIViewPropertyAnimator+Promise.swift */,
+				6AC6A930480C6D49FBE9CABC861E7B9F /* PMKUIKit.h */,
+				F83A99AE3895216765C532D36951A1D2 /* UIView+AnyPromise.h */,
+				7D9E0A291B69EAF8057416D377913C49 /* UIView+AnyPromise.m */,
+				7A0FE94A2A17EC2649755A1A87228694 /* UIView+Promise.swift */,
+				3FA5CE28CE7C060A546BAD90B222B573 /* UIViewController+AnyPromise.h */,
+				3730C8C8F50BAFB7408B176B346076CB /* UIViewController+AnyPromise.m */,
+				C3B1986B76BE8BFA1F47E63519975F7A /* UIViewPropertyAnimator+Promise.swift */,
 			);
 			name = UIKit;
-			sourceTree = "<group>";
-		};
-		9E199CC8FC256BDE3D856C9E520C77ED /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				474EB8FDCD80C8B9B1C48E130D9C4C7E /* VcCrypto.podspec */,
-			);
-			name = Pod;
 			sourceTree = "<group>";
 		};
 		9FFACD569E68DB67EF6AF696B80434CB /* Pods-VcCrypto-VcCryptoTests */ = {
@@ -912,6 +768,55 @@
 			path = "Target Support Files/Pods-VcCrypto-VcCryptoTests";
 			sourceTree = "<group>";
 		};
+		A6C5B7473ED6E40457559B8FF80D3292 /* CorePromise */ = {
+			isa = PBXGroup;
+			children = (
+				4E05F323974C2D7833417A8D7F5BF127 /* after.m */,
+				4353F498EF4D62AA7DBFE28F3E5F8320 /* after.swift */,
+				5ED21860AAC5C75752EBA9698A6DED74 /* AnyPromise.h */,
+				55C3960246814482A3687E5F19E64CE5 /* AnyPromise.m */,
+				E96E0F7600B891D2D2D4C7B9138C1B0B /* AnyPromise.swift */,
+				E28FE3E8C393FA4C5D3C55E303F6643E /* Box.swift */,
+				15BEF5399736F43655C01758148FEA87 /* Catchable.swift */,
+				96E61770C0AF5A531C4B9A50F318CFEB /* Configuration.swift */,
+				BFB01212F7A6B19DC6A3E26AFC4ACF2C /* CustomStringConvertible.swift */,
+				1BE938727019BB721FCF3A08FBD11E3C /* Deprecations.swift */,
+				A2EA213B48DC28B4037837BDC7410D0C /* dispatch_promise.m */,
+				06C3BAEBD327280F000B6BEE407EB681 /* Error.swift */,
+				97DE9991CD4766CCF7DFD839AC848D4B /* firstly.swift */,
+				8536E2C3428FEC0CBC83BA96D7B1F178 /* fwd.h */,
+				03EA20861088FACDC61C8C51E1FAF700 /* Guarantee.swift */,
+				42014D231E070D573934F2D44AE6706D /* hang.m */,
+				E2CB2ADA690E2910241611766C32E2F3 /* hang.swift */,
+				243ECF8B1AF363D562935D9D329BEA2A /* join.m */,
+				F01F930C93559DD4B9F420D5D237E6C9 /* LogEvent.swift */,
+				14F2F95317A023EF6B665F27F5306CCD /* Promise.swift */,
+				EB522A7F729177C33D085ABD72CA65F6 /* PromiseKit.h */,
+				3500F51E4117B09F15D007270B88AE4A /* race.m */,
+				5371667600D079FC77568EE611CC1267 /* race.swift */,
+				480FC1D442C11B3F90011531FD2A997E /* Resolver.swift */,
+				2270F53468815DE0FC08756D6CCFA341 /* Thenable.swift */,
+				90F2E32C2C79B160376BBBA102BC4931 /* when.m */,
+				BC78C53213A88D95B49A8F6B925B1555 /* when.swift */,
+			);
+			name = CorePromise;
+			sourceTree = "<group>";
+		};
+		B28154FAF874AD2D412BB56438F792A6 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				48DD6794BCB3DF6CB5BA5BFAE048B60A /* PromiseKit.modulemap */,
+				786D51C7D2122FE69C614EC855704160 /* PromiseKit-dummy.m */,
+				63700342A59B39A2809E6816A2E116F5 /* PromiseKit-Info.plist */,
+				CCDD9EEB414D58596A027510BAC84C0D /* PromiseKit-prefix.pch */,
+				5486BABF44C7078871EADFE753E1A38A /* PromiseKit-umbrella.h */,
+				B59C04F48A9014381511F9623105A875 /* PromiseKit.debug.xcconfig */,
+				4A3312121FB6F7D6B4479466A46AD072 /* PromiseKit.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/PromiseKit";
+			sourceTree = "<group>";
+		};
 		B88CA422561E85D5478CBC9BD258C108 /* Pods-sdk-sdkTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -929,78 +834,21 @@
 			path = "Target Support Files/Pods-sdk-sdkTests";
 			sourceTree = "<group>";
 		};
-		B9C25F747B075FFE207E82D3D005768F /* bitcoin-core-secp256k1 */ = {
+		CDFF04ACF03A23404AB4A2AD57F39831 /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
-				FFDB7DCF590CA80CF4976FF708447B59 /* assumptions.h */,
-				1AB72A6669EFC71F29FFE5B951A85B64 /* basic-config.h */,
-				57F77B70178D80BF5067756DE869B9A8 /* ecdsa.h */,
-				F5D86CAF969ABF249E5F44E80F70D6FC /* ecdsa_impl.h */,
-				F4BD4022F180C944F0C037A0C4C719A3 /* eckey.h */,
-				3CDA2CD70FF5E2272DA0F95B8EE4EEDB /* eckey_impl.h */,
-				5F9948ADFF702D01AEECEFAF7656A276 /* ecmult.h */,
-				FBA66929FE4491B4DC0CF67A2ADAC42E /* ecmult_const.h */,
-				938B36D96A3F24AA449046C0753CAD45 /* ecmult_const_impl.h */,
-				1C04FB4E47DE959155FC5E512E26D630 /* ecmult_gen.h */,
-				21E61B955C6DCF3B115F398121FF0A43 /* ecmult_gen_impl.h */,
-				4D78F27BB75E50CD2FD6188C55E27373 /* ecmult_impl.h */,
-				EEC3F3EDA395D7520424BD541862AA16 /* field.h */,
-				E9620E1C596E2E47F3B680F788369306 /* field_10x26.h */,
-				B6A9E8F5AA16BDB7CA095B0B132DF844 /* field_10x26_impl.h */,
-				254036BDF02E8B5E0A0B3B8474AFF790 /* field_5x52.h */,
-				6555C520A49FE51A6FBCB72A7E4E0644 /* field_5x52_asm_impl.h */,
-				4CA73410BAD385AFACD9732A9996859E /* field_5x52_impl.h */,
-				0AB30D83F5947CFF59E69DFEE6520A2A /* field_5x52_int128_impl.h */,
-				D47943C7EA6F97F2323EC971B75DEE8B /* field_impl.h */,
-				A3FBB9478AAA18A15E7DBABBCEBC01FD /* group.h */,
-				4D555BB7F954235881771E11B587CF7D /* group_impl.h */,
-				75FD3CD25D90F4DD1F4FE54AF362269C /* hash.h */,
-				59638B0B1B5532B717C69B560940EFDC /* hash_impl.h */,
-				A02DE9E74DEB9A256A9F457666C21E46 /* main_impl.h */,
-				F67418A4C5BB88BB468E0B60C5FA963E /* main_impl.h */,
-				8B494C053D2E4BB1066CA1D24EB1AD6D /* num.h */,
-				7CB299F3A6210695F1FD309BAA9AEF75 /* num_gmp.h */,
-				8AA69F9C9527192D189D7D5780F7C574 /* num_gmp_impl.h */,
-				EAF1187BC13645A12EACBF172AAA963B /* num_impl.h */,
-				092C8A6D04604C2959105D64F9C965C9 /* scalar.h */,
-				4CBA08A665295E2056C26FFEBDD34ADC /* scalar_4x64.h */,
-				9F7E6155D9D0C1F05D36EF36221BEDAB /* scalar_4x64_impl.h */,
-				50DDFDB314A42CE9CC5746DF0AC0D1E5 /* scalar_8x32.h */,
-				29C74ECC00EE31C2D221E471208650E3 /* scalar_8x32_impl.h */,
-				82755C006283793A77E1BD87508560F5 /* scalar_impl.h */,
-				DE99681D72B645575A3B31F1878B6B3E /* scalar_low.h */,
-				766F71A777BA671115D8917E39170A1C /* scalar_low_impl.h */,
-				C61EEAA77AC36DB5F3679E2891202A98 /* scratch.h */,
-				2FADC424BE7BF6C4154E9EEC1C2D6B37 /* scratch_impl.h */,
-				D62F2EFA7AB63909208572E68F4BB8E3 /* secp256k1.c */,
-				11072080A5FE47752615651BC0F878CB /* secp256k1.h */,
-				BC57494B77FCC93ACACB308CF9E3631C /* secp256k1_ecdh.h */,
-				D4C549A9D2D3EADF98D88710605C195C /* secp256k1_preallocated.h */,
-				9118411113C8AC271ADBD729F3A08037 /* secp256k1_recovery.h */,
-				1BFEBCBBC1EDAFBB554B2FCCFBF5B5D0 /* tests_impl.h */,
-				04DE1D978C2B59117A5735206C047D69 /* tests_impl.h */,
-				2817BCFFD9EBF0A304905121E1824141 /* util.h */,
-				916CA7DF051F1A81297D56536920167C /* Support Files */,
-			);
-			name = "bitcoin-core-secp256k1";
-			path = "bitcoin-core-secp256k1";
-			sourceTree = "<group>";
-		};
-		CE0417C5E574E072BA699AE196741CA5 /* Foundation */ = {
-			isa = PBXGroup;
-			children = (
-				E586CD62595B6116F796EC6D4087F32F /* afterlife.swift */,
-				E5C06A45625F17E4E194C69314E4A145 /* NSNotificationCenter+AnyPromise.h */,
-				1848FB9DB0AE45FF4D680907B0E98523 /* NSNotificationCenter+AnyPromise.m */,
-				E99BF2586AEB072F8DB1E6B6BDDF8F4C /* NSNotificationCenter+Promise.swift */,
-				B26A56E3B8F06F12A9276D5074A5B4A7 /* NSObject+Promise.swift */,
-				0C63CCB86A6BC83026C7E55E16E2B45E /* NSTask+AnyPromise.h */,
-				3237E0A6AFFEDEFA869A0B935911434A /* NSTask+AnyPromise.m */,
-				8E073F32B53B1BF948756FC0C654B624 /* NSURLSession+AnyPromise.h */,
-				19467827B2F45A595370C58513268EDB /* NSURLSession+AnyPromise.m */,
-				9DD4500D2B1C260833A564AA518A3283 /* NSURLSession+Promise.swift */,
-				0FD960E5387CEF78BCE09BD9B0D7E080 /* PMKFoundation.h */,
-				49CA7A569C295010860D536FCC3324BF /* Process+Promise.swift */,
+				CAFEE0F74E0C9294EB8B6D4566B5914C /* afterlife.swift */,
+				7C65CC0177A8C20AED52EEEA3B2271AC /* NSNotificationCenter+AnyPromise.h */,
+				B3CE95F3C13990139072A473BAA550A7 /* NSNotificationCenter+AnyPromise.m */,
+				A62A210C649AF5DFF8193A3D6CF19B15 /* NSNotificationCenter+Promise.swift */,
+				B2EFEE9B9328F545CE210D88B3810EC8 /* NSObject+Promise.swift */,
+				4FCC8EEC3595B913B19D91A502CF2E79 /* NSTask+AnyPromise.h */,
+				C0CC4441F818499CA22F18AF8BEBA978 /* NSTask+AnyPromise.m */,
+				51CC579DCE56A91B90B9E605836D243A /* NSURLSession+AnyPromise.h */,
+				A02ACE07DAF9653C72C85571C867DAF5 /* NSURLSession+AnyPromise.m */,
+				5F81E3F134B8E512031BF48D62DEAD8D /* NSURLSession+Promise.swift */,
+				B683C4D0E6E23E3F79339391D128B996 /* PMKFoundation.h */,
+				D6E557CC48D00AA85F709DBA6037FBC2 /* Process+Promise.swift */,
 			);
 			name = Foundation;
 			sourceTree = "<group>";
@@ -1011,10 +859,69 @@
 				9D940727FF8FB9C785EB98E56350EF41 /* Podfile */,
 				3EC135C71EFECC181A0DD6C8F076345A /* Development Pods */,
 				1628BF05B4CAFDCC3549A101F5A10A17 /* Frameworks */,
-				470E18A0DCB23DA2D7B4BCC1B608C139 /* Pods */,
-				8CCD289A063E8649185814FD38A2177B /* Products */,
+				6E4148D7DD83DDA70A8AA25F8E68C9E4 /* Pods */,
+				FF9C74392E7B6B62A1253A57E3F785CD /* Products */,
 				EFA2E36429D8A0C44283BD06BC159AAF /* Targets Support Files */,
 			);
+			sourceTree = "<group>";
+		};
+		D46B219C9D179C29B17CC28550FA96E7 /* secp256k1_ios */ = {
+			isa = PBXGroup;
+			children = (
+				1A6B33191F8222535EDB4F35440E942C /* basic-config.h */,
+				D727184A6E2EA9D853BA156FB0E2DD05 /* ecdsa.h */,
+				E7DA78A45CEFDA2BD66E6E5BD437B1B9 /* ecdsa_impl.h */,
+				1897E6D2765165B3D189B16520A04922 /* eckey.h */,
+				BFDAFDA15AC40DE93C97A4D5D27D7A74 /* eckey_impl.h */,
+				9341A118F888C938C6A921D4C480EF20 /* ecmult.h */,
+				4B214A3CA7FE949A02513F6722C0C2D0 /* ecmult_const.h */,
+				6C7967D76BD5422CD8624857B4078167 /* ecmult_const_impl.h */,
+				DD76667382B20B88BB8935E1812CE344 /* ecmult_gen.h */,
+				329A591E9BEEE33DE0B2644FBBAB3ED0 /* ecmult_gen_impl.h */,
+				A0AE03803CB1B486BF7739D28DE295C1 /* ecmult_impl.h */,
+				AA70392775FC09CA0A5566C942B2D5D7 /* field.h */,
+				3C8A62387E870EA43D03CA53DCEE0C1D /* field_10x26.h */,
+				23DE15C88C33ED4A73994B094C2643E3 /* field_10x26_impl.h */,
+				AB7EDE0742AFF5F3232CDA094EB7A124 /* field_5x52.h */,
+				05EE3D1F1EAAB7A8F7D94CFDDCB73990 /* field_5x52_asm_impl.h */,
+				4030316DDADF3632794E6A712C7C35C4 /* field_5x52_impl.h */,
+				F00A8F673B90C211CDFBFDF738DFBF27 /* field_5x52_int128_impl.h */,
+				E524558EF7B0FA2C58EDD5F2A6B8ACF5 /* field_impl.h */,
+				E73D5A57C8F50B074932D85A899DCD0C /* group.h */,
+				174ED2AFD0A4B7DD241777987932DDD5 /* group_impl.h */,
+				7B20DE0D50C31BFF7CD0CC638E73A030 /* hash.h */,
+				C26428FE936F8E44D28B7EF6EF32A837 /* hash_impl.h */,
+				963CB0AA85418F81F9A57689163ACD89 /* lax_der_parsing.c */,
+				FC4E9889F9E1F402C3DB2B3A90676C11 /* lax_der_parsing.h */,
+				D000FD533E4085400D819CE04E649689 /* lax_der_privatekey_parsing.c */,
+				E80CBCCF2CEE58DD6AA7B3689BD17DA6 /* lax_der_privatekey_parsing.h */,
+				69CF1B9477AEE675CD98E6C7931DCC15 /* libsecp256k1-config.h */,
+				E904D2F45316FC04196883E3BED455A8 /* main_impl.h */,
+				B9F2029FCF6C147890BBFA918230D1D3 /* main_impl.h */,
+				5C8DCB88CC65385A49D845D5907D311D /* num.h */,
+				C865F5F867FCB991FC50CA9687D105F2 /* num_gmp.h */,
+				2A4B21AB340724F56E2462F8F700278F /* num_gmp_impl.h */,
+				66EBE3D286B36B60CC645AA66BBCDD9F /* num_impl.h */,
+				19FD5BA70C94540554C882446158858B /* scalar.h */,
+				1211768920E8D71136FB3AC4C9C3AEEC /* scalar_4x64.h */,
+				73DA0DBD3D421C8A8A93C2F517ED6B48 /* scalar_4x64_impl.h */,
+				8B8AA9E8AFD6D1E00286A07C4AB350D8 /* scalar_8x32.h */,
+				E881A39F7EEB33AD66E34B200A5476EC /* scalar_8x32_impl.h */,
+				D4A74638C4ED8D0224F351F76E29991A /* scalar_impl.h */,
+				A687BD5D47AAA0C72FE790A90D841E5D /* scalar_low.h */,
+				FFDD3C629AC54926AD39A2158000BCFD /* scalar_low_impl.h */,
+				BCFF8CAACC2DE737E452F090CF9E6254 /* scratch.h */,
+				CD4D03B1A375066A4DB77D0E462E918D /* scratch_impl.h */,
+				E4321D605DC983B72C2F14B9F58BA5E8 /* secp256k1.c */,
+				42183EE1C6E2CBE0704C8213F9D97712 /* secp256k1.h */,
+				9BB7072EC80533A9DB4161D418152882 /* secp256k1_ecdh.h */,
+				3A29BF806D25C7FB68DA035F723BCE26 /* secp256k1_ios.h */,
+				10711BE548AED40F4C2EE0422167D557 /* secp256k1_recovery.h */,
+				4A1767B5AD12E1BB6DC572CA58F3C5D5 /* util.h */,
+				FF9DE9D3D225BF750AA437C9E7877485 /* Support Files */,
+			);
+			name = secp256k1_ios;
+			path = secp256k1_ios;
 			sourceTree = "<group>";
 		};
 		E2983683FD097A93297E2F5D4E382B36 /* iOS */ = {
@@ -1024,40 +931,6 @@
 				312B988EF117AE4DE76A268D970131FE /* UIKit.framework */,
 			);
 			name = iOS;
-			sourceTree = "<group>";
-		};
-		E52877076279A3791E562C74D0F999B5 /* CorePromise */ = {
-			isa = PBXGroup;
-			children = (
-				905C59B04706BE9C024D4C97CC37616D /* after.m */,
-				F673C693801031932449D23955759008 /* after.swift */,
-				AC39F1E8A5A681B26E9B512F3B2C90FB /* AnyPromise.h */,
-				9FFFD33A919760ADE3176D92B725531C /* AnyPromise.m */,
-				F4F6E5B27BB5CB6B4D2846DDF1A5F3CC /* AnyPromise.swift */,
-				ABBA28790FD69DCD34B262FA4794D03E /* Box.swift */,
-				D170FB93A9659AC62EB96EEFBD07F89A /* Catchable.swift */,
-				220DA8A861A195B90F9F7D54C61E3B56 /* Configuration.swift */,
-				AAC754938C9FB23E1FEF34D5F307D640 /* CustomStringConvertible.swift */,
-				F49BCF208D11EE478A05AAF9800A7E31 /* Deprecations.swift */,
-				522C3CAACE0477E91BB6A3A9D9E9F663 /* dispatch_promise.m */,
-				BBF5A6FC4E52452C68782CE2F701BA4D /* Error.swift */,
-				CA31378D72B1854484A3AE24090C9E23 /* firstly.swift */,
-				4315C0CC711137AAEB92AFEA7D43D25A /* fwd.h */,
-				A35BC4349E1FD5846C567D70FCFF0AC4 /* Guarantee.swift */,
-				4A7EF5955F461D82227208AFCEDECA69 /* hang.m */,
-				FFE9610DD10C3F32371E4BD06B2F25A5 /* hang.swift */,
-				4F3593DF8DEA8D63547441DC7AC2A080 /* join.m */,
-				12DC8F7031D40A0A47C4F18F42315CAC /* LogEvent.swift */,
-				C00AA9B85AE0296B38EE49F201668070 /* Promise.swift */,
-				A35A5A64A2BA545E671773BE11179C05 /* PromiseKit.h */,
-				71B2B261C3EEEC9F92C5464CD0FAAA13 /* race.m */,
-				D04597055A1A7A7F198D489FFEA7C893 /* race.swift */,
-				A5C6B94622B196AE1DE59D3276DE73D5 /* Resolver.swift */,
-				EFC04EF6E845E7832336EF1B12AC9E04 /* Thenable.swift */,
-				B8CDE7E03F7FFBAB8AEF76950B03A3DB /* when.m */,
-				360908940B4F77BADE3771D2B9439229 /* when.swift */,
-			);
-			name = CorePromise;
 			sourceTree = "<group>";
 		};
 		EFA2E36429D8A0C44283BD06BC159AAF /* Targets Support Files */ = {
@@ -1075,117 +948,141 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
+		FF9C74392E7B6B62A1253A57E3F785CD /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0421A70AF7B3109297422E3D8F394BAE /* Pods_sdk.framework */,
+				0894F527EF50033A03AB4F13D833DCE2 /* Pods_sdk_sdkTests.framework */,
+				A1477CF5E82E4955EE595485E7BF1807 /* Pods_VcCrypto.framework */,
+				926DFDA3FD72FB3DE287F706A3AAF6AA /* Pods_VcCrypto_VcCryptoTests.framework */,
+				2B5B93F38F19F3082CFD2F55752F335E /* Pods_VcJwt.framework */,
+				ECF647F9FA7A25AEB7A9E65F7BEAC508 /* Pods_VcJwt_VcJwtTests.framework */,
+				4AE0F0DFA89130C50F8620807B62715A /* Pods_VcNetworking.framework */,
+				C12A084838426886105BA4275B30295B /* Pods_VcNetworking_VcNetworkingTests.framework */,
+				002B1E88BA14EBF633CD66EBFBA107E9 /* PromiseKit.framework */,
+				797B7243FC6C7A8F94A8CFA9E05C458C /* secp256k1_ios.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		FF9DE9D3D225BF750AA437C9E7877485 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				BBA5160D4602B02FC6AA8B82A7071A13 /* secp256k1_ios.modulemap */,
+				DE6FA170EC3BDE6DB448239C1942BD6C /* secp256k1_ios-dummy.m */,
+				16A9AC73D66FC840307B490F032B64C9 /* secp256k1_ios-Info.plist */,
+				62855D2CE3CAD80DC3B241E9F1D7EF52 /* secp256k1_ios-prefix.pch */,
+				73AACAB60C21E8887475CF5FF0D76C5E /* secp256k1_ios-umbrella.h */,
+				FAE13A4D4D22D7C0B347EE84F1E24B3B /* secp256k1_ios.debug.xcconfig */,
+				C31433B9FC270C8D03B007BF97EA5C22 /* secp256k1_ios.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/secp256k1_ios";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		03D1E6F1D850CAC2B2529D643C875D4A /* Headers */ = {
+		35B850D2943980431190C68D92EC06D9 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8BD443A42C5C718BC8843BBC83254152 /* Pods-VcNetworking-VcNetworkingTests-umbrella.h in Headers */,
+				AD058298CC455015A3802D257DAA94BE /* Pods-VcNetworking-VcNetworkingTests-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		103703A283E676EA9A3226C39131E29A /* Headers */ = {
+		474F29A0F29B8DBCC6FAD58C756C9686 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E14E81F881B656B09A1B3B2D00475E01 /* assumptions.h in Headers */,
-				DF8EAD4722AC498D0E239DFBF83A7B68 /* basic-config.h in Headers */,
-				61C0CED9E188678C919F058C64CBE917 /* bitcoin-core-secp256k1-umbrella.h in Headers */,
-				0CC6F25BB8104721CC132F3A3492DE79 /* ecdsa.h in Headers */,
-				6D8BA89C98C379ECED581370EBE1CD92 /* ecdsa_impl.h in Headers */,
-				8F3C62F12DCDBCC079618CCBA54542F8 /* eckey.h in Headers */,
-				ADA3CD6798264852BCE51FA3CF137E52 /* eckey_impl.h in Headers */,
-				7CD5B6F4F5CF8C28D698E81E0B080878 /* ecmult.h in Headers */,
-				6A074E2F079D738F3D8237BB2DA665FA /* ecmult_const.h in Headers */,
-				CEF1FFB8DC404FF933102526A708A297 /* ecmult_const_impl.h in Headers */,
-				5175A9213A70AAAC436BED04833C7F57 /* ecmult_gen.h in Headers */,
-				8A52D90A0E37D2772C8D19261148EC3B /* ecmult_gen_impl.h in Headers */,
-				513C5C141F115DB01F9C5877EACC498D /* ecmult_impl.h in Headers */,
-				869FFDEE205BAD4838606AFC0E24DD67 /* field.h in Headers */,
-				5969807D0767490C7FAF57E73E433D3B /* field_10x26.h in Headers */,
-				6468A5C13CF2D853BA8D699574D5FF44 /* field_10x26_impl.h in Headers */,
-				7312821F81430D0DDA5DE998A95E8282 /* field_5x52.h in Headers */,
-				3F7B9490387407CEFDC4306E87039BFA /* field_5x52_asm_impl.h in Headers */,
-				AB5AE7BB2DA97A9E849725A2413F33DA /* field_5x52_impl.h in Headers */,
-				127CC05729CA6C49F23289CBD1B33A21 /* field_5x52_int128_impl.h in Headers */,
-				615CDF6B72AF227417A0952CEEDC3848 /* field_impl.h in Headers */,
-				7CEE635BA2464A2A20B2B4F84FB6C6B1 /* group.h in Headers */,
-				EA71BE3EA1C0FCBF64CCE199F79DC03D /* group_impl.h in Headers */,
-				EF28F9227CA6F4ACE4C7618C881DF70D /* hash.h in Headers */,
-				27E6D7525C5508FF01EC9CBEF42E4509 /* hash_impl.h in Headers */,
-				93E32E0840F99DE79421E31E8B886E6E /* main_impl.h in Headers */,
-				E1E9D3520BD28ED3C564D9BC5B890D57 /* main_impl.h in Headers */,
-				B1DF3554388CDFBE4050CE9D3FC4C616 /* num.h in Headers */,
-				F4A258988E782EE7CF2B810E54C12F3D /* num_gmp.h in Headers */,
-				A3E609FDE0A65BEB8FCD6C2CA37B59CA /* num_gmp_impl.h in Headers */,
-				9C83E564AADD9C1F621FAC19DE07F912 /* num_impl.h in Headers */,
-				2A9A2ECFC5B9D43FD4754646294BDA2E /* scalar.h in Headers */,
-				0062DDC5C8321E8463CA7DC4A390B63A /* scalar_4x64.h in Headers */,
-				67135B603F808E68183713E5765DD1F1 /* scalar_4x64_impl.h in Headers */,
-				9EC14E8CEDF7D656021576C555B4BE95 /* scalar_8x32.h in Headers */,
-				66D51CFAD06894D21D81875E392F9F9C /* scalar_8x32_impl.h in Headers */,
-				128123D41007EF2CEE6FEC4B6DDFABDF /* scalar_impl.h in Headers */,
-				04962D6927F0EBC7B36D70EFCB8341ED /* scalar_low.h in Headers */,
-				5218E23F7F9BD828D2370E15EA536B9C /* scalar_low_impl.h in Headers */,
-				9359B5BEDE0F9A1C0CDE4B8B2DFC8C4D /* scratch.h in Headers */,
-				F2C74E8681F4343C2036885563F88E9C /* scratch_impl.h in Headers */,
-				5553F16DA39F70B1B6EF4CD0B388F066 /* secp256k1.h in Headers */,
-				C791131C5098B85172F7B1B7BB1C9CF2 /* secp256k1_ecdh.h in Headers */,
-				DCB42ABED700C2118F77F8FDCF5F70B3 /* secp256k1_preallocated.h in Headers */,
-				6E59D57B4AF73D833E81E8D380B6285D /* secp256k1_recovery.h in Headers */,
-				590206EDC2307E8C2168320D0003C59A /* tests_impl.h in Headers */,
-				173B398B33FF1967C97F1C97E2457BFF /* tests_impl.h in Headers */,
-				9AF1CB9B6F8E5EBE5420B396EC003604 /* util.h in Headers */,
+				9704BD569F465A2D6B5EC452D3E8CFE2 /* basic-config.h in Headers */,
+				9C7DC10D67B24CA46E70D2C674FEAD1B /* ecdsa.h in Headers */,
+				9A85128E12ED34C4C5FDA9CADA876462 /* ecdsa_impl.h in Headers */,
+				9B0118B72E0FB5FCE33187FD43E94137 /* eckey.h in Headers */,
+				4CF8B1A3715F54EC0194098636CBEBAD /* eckey_impl.h in Headers */,
+				F4643B26A69537390AC94A9F3017DC26 /* ecmult.h in Headers */,
+				17E1BABDD636ECB46EACCF1D2E968663 /* ecmult_const.h in Headers */,
+				A38111C63BA9D2A040554DE79EE13813 /* ecmult_const_impl.h in Headers */,
+				EA5977C16C7EC9B9DE9E72B370EFF0B5 /* ecmult_gen.h in Headers */,
+				76ECB04E1EAD266567EFF5ED8269E991 /* ecmult_gen_impl.h in Headers */,
+				9D1156FDFC60ED30C80F2009BEC3DE76 /* ecmult_impl.h in Headers */,
+				2A1693A6903F4222FE5AE3EFE0E545EB /* field.h in Headers */,
+				3FC467587AAFD0ADA9DC26B03101D221 /* field_10x26.h in Headers */,
+				3F6A7BDD385B44952FFB8AB61EE7BB82 /* field_10x26_impl.h in Headers */,
+				FA72F55097C107BCC053CC59D04EE3C5 /* field_5x52.h in Headers */,
+				7423BDF21D71F98D9733CEE09EB0BD57 /* field_5x52_asm_impl.h in Headers */,
+				E59846B9FE72CE029F212C6B52C00435 /* field_5x52_impl.h in Headers */,
+				417C05FB4C3B1DBD1D84BB76D21ADA07 /* field_5x52_int128_impl.h in Headers */,
+				5D4CEF2F417A8E04098FE31934C51794 /* field_impl.h in Headers */,
+				67C06653732CA876A501061CB645082E /* group.h in Headers */,
+				0845026EB21CF5C376D9EF76A06E733E /* group_impl.h in Headers */,
+				5FBA639EDCA4082B4DB5FF125C5E680B /* hash.h in Headers */,
+				E0190E57023E33FE1F47BF14BEEA7B56 /* hash_impl.h in Headers */,
+				65B07BACFDF68A6461EC8D3A7AB3AD3B /* lax_der_parsing.h in Headers */,
+				D3ECE45BA61EB7CF0EEAC491F1D8BE97 /* lax_der_privatekey_parsing.h in Headers */,
+				6CA3BCD7F8A8F4F945E467F641AB433E /* libsecp256k1-config.h in Headers */,
+				A7D32BDB7BEEBE2C2F217E15ECE5D1A0 /* main_impl.h in Headers */,
+				7E656DC2F28CC3B4A95563A61832356A /* main_impl.h in Headers */,
+				84724F5B857D00F41A35A247B3A278BD /* num.h in Headers */,
+				0847F7F254A89E19126A52D24FBC5CA2 /* num_gmp.h in Headers */,
+				563FD527C414D9E30F685148B632C828 /* num_gmp_impl.h in Headers */,
+				D7771ACA5665C207C30C5366F6D0F90D /* num_impl.h in Headers */,
+				8E6A9D3B93C576616729CDADBE48A532 /* scalar.h in Headers */,
+				FB81AF64500747F8A86BF49639A23478 /* scalar_4x64.h in Headers */,
+				3F56139E64FD0396BF78AF881DDDD7D1 /* scalar_4x64_impl.h in Headers */,
+				7276295CFCB4D103FC4EAD2373F52EA4 /* scalar_8x32.h in Headers */,
+				BB37D18AEF801324A67C9BE130439907 /* scalar_8x32_impl.h in Headers */,
+				C4343A9A01F4D90B9B98C30806FC050D /* scalar_impl.h in Headers */,
+				54E27E1C5982BE6F6B74DE723F554100 /* scalar_low.h in Headers */,
+				32F4BD576FE7040B473AE1E3D3D8346A /* scalar_low_impl.h in Headers */,
+				B8FF6723C422C3C93D8446A935CA80C6 /* scratch.h in Headers */,
+				D84861ED689D035C63609B0654986E3D /* scratch_impl.h in Headers */,
+				0ACE05FCD4954CD9EF618CE4046E280F /* secp256k1.h in Headers */,
+				2DC7815A7622771B86E4CBC2D072E790 /* secp256k1_ecdh.h in Headers */,
+				60317F9BD96CF2B27323A8BCAAB53A1A /* secp256k1_ios-umbrella.h in Headers */,
+				114144939176AEB7EC8F53385679FA5C /* secp256k1_ios.h in Headers */,
+				6481564A095352F8F5933E69BC7C5C48 /* secp256k1_recovery.h in Headers */,
+				80C9CDA192D4A4B9A2811AA9C1C37CD8 /* util.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3648EA904450B7DF57C3FA7260799422 /* Headers */ = {
+		4844A6ADEB0D28232D8FE5F9062941E5 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				47C54EFB16CC84D2D9EC24AFF465E521 /* Pods-VcCrypto-umbrella.h in Headers */,
+				E6CF645B0BA0747D65D0A1D978FD97C1 /* Pods-VcJwt-VcJwtTests-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3C329D26DA365739DDE0D93FEA500739 /* Headers */ = {
+		5FCD9B86D597F5E93FF1C7A803A9489E /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				94C4DC0D39AE3F670ED2C15B9F34807E /* Pods-VcCrypto-VcCryptoTests-umbrella.h in Headers */,
+				93650CA8A56322E0184BFC80AAE18A12 /* Pods-VcCrypto-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		44BA0144F62D12850217D47610DC0C8A /* Headers */ = {
+		7C9873821A2E597D7A507B455560FC6D /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A3CBE98339DBAF5901D864620063C79F /* Pods-sdk-sdkTests-umbrella.h in Headers */,
+				3C824938EF654C5F5E455E891CBBC99E /* Pods-VcJwt-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		739A4CFB3EC4BA3DAC2A8EA9EB9C4B11 /* Headers */ = {
+		84F2C0988AF381A99D3B9ED593115A21 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8AFF8E5B1323A6458FE2E55D280EE963 /* Pods-VcNetworking-umbrella.h in Headers */,
+				0FB197AB0C07D678DA85A5748D7A89DE /* Pods-VcNetworking-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A08B55DF095FD501A19FB7890F8980D3 /* Headers */ = {
+		9BB55A042A60033219A3F141A8AB0F49 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				17AAF2F787966C84BFAA95423D4D2DDF /* Pods-VcJwt-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		AC2203DA80B1741CA5D9837854C92B43 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				36DF15BDC7973AFCF4B2C4560DF684F2 /* Pods-VcJwt-VcJwtTests-umbrella.h in Headers */,
+				8FA5303831C7F11D5E98DC8A38FF05DB /* Pods-VcCrypto-VcCryptoTests-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1207,11 +1104,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CB59797235B9ED6190A55D810E902F7B /* Headers */ = {
+		DDD352E261410DCC09D7989617F04347 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AF4C0BBFF32F4BF0F0B83771115FCFDA /* Pods-sdk-umbrella.h in Headers */,
+				04D0046311C21A01BA8B8D048EDCFE95 /* Pods-sdk-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ED17099A8C26F3B0130AC5AAE78326F6 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A84F84F824A6025C19286C54A1CA76AF /* Pods-sdk-sdkTests-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1220,18 +1125,18 @@
 /* Begin PBXNativeTarget section */
 		0391E81BCCFB80794D86A002B009DE90 /* Pods-VcJwt */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 9E2153A753C83B116C4FB14BC1F849FB /* Build configuration list for PBXNativeTarget "Pods-VcJwt" */;
+			buildConfigurationList = 6381A2B4D87ED43A9681692F3DE751B3 /* Build configuration list for PBXNativeTarget "Pods-VcJwt" */;
 			buildPhases = (
-				A08B55DF095FD501A19FB7890F8980D3 /* Headers */,
-				278E1F7A6ECF73FFD77BD789D1F83613 /* Sources */,
-				FD4372A1FEE3A3252A8B4C3902B46746 /* Frameworks */,
-				55BA245CED2D5D689E700EF85293026B /* Resources */,
+				7C9873821A2E597D7A507B455560FC6D /* Headers */,
+				7B8EF39BB5BB472A61BAA9A98587CE93 /* Sources */,
+				9D6580D46BB902ECDC53238223D21ACD /* Frameworks */,
+				89DD86BC9B608D1CCE1E1730CA521681 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				80F8802E60139D49A0D93A471C27F28A /* PBXTargetDependency */,
-				A16792503F59DF4AD640772BC41D2AC1 /* PBXTargetDependency */,
+				0016BC81A6872DA571556C0534423C66 /* PBXTargetDependency */,
+				5263D5668B62C71B665FF0D379D5D2D3 /* PBXTargetDependency */,
 			);
 			name = "Pods-VcJwt";
 			productName = "Pods-VcJwt";
@@ -1240,56 +1145,36 @@
 		};
 		0B2DE02423056330E81636C658DDEE2C /* Pods-VcCrypto-VcCryptoTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 69A1FDE87F3A343E85BF3137B1130788 /* Build configuration list for PBXNativeTarget "Pods-VcCrypto-VcCryptoTests" */;
+			buildConfigurationList = 5E3AF5E3D41514F64AA40EDD0C5F6449 /* Build configuration list for PBXNativeTarget "Pods-VcCrypto-VcCryptoTests" */;
 			buildPhases = (
-				3C329D26DA365739DDE0D93FEA500739 /* Headers */,
-				BBBA3C5F33BCD06315AD5026858DAACA /* Sources */,
-				4EAAD77126A1982C6A4BD14B4580C28F /* Frameworks */,
-				E5C7ECF28675E84862A855355A6CD95B /* Resources */,
+				9BB55A042A60033219A3F141A8AB0F49 /* Headers */,
+				E8AD849CA9B0EE18FC01468B1A291D0B /* Sources */,
+				B8ED4F7B27BFC5BBB5EFC5E24588A1D5 /* Frameworks */,
+				7DC54003C7AE571D3FA8682E8E7F04CB /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				9C098115BD15AB16933397D88360D89A /* PBXTargetDependency */,
+				959AE62CAA75D97E225DB964AC51C965 /* PBXTargetDependency */,
 			);
 			name = "Pods-VcCrypto-VcCryptoTests";
 			productName = "Pods-VcCrypto-VcCryptoTests";
 			productReference = 926DFDA3FD72FB3DE287F706A3AAF6AA /* Pods_VcCrypto_VcCryptoTests.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		3020FF5BE409E86C04853BBDEF3E50A7 /* bitcoin-core-secp256k1 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 9216F241A7F28247C884C8E5849B0204 /* Build configuration list for PBXNativeTarget "bitcoin-core-secp256k1" */;
-			buildPhases = (
-				103703A283E676EA9A3226C39131E29A /* Headers */,
-				B8E9CB25BA5D860E1C68C7CB65C93803 /* Sources */,
-				BEAE199313ADB2B68B7CF51BFEB1B909 /* Frameworks */,
-				A1F1981C3F7BA5D94269956DEAB033D6 /* Resources */,
-				7724A5C30DD8B8A784458B3F7DA5D824 /* Copy include Public Headers */,
-				D135A680FBC3E227BBC77B52F877E0FE /* Copy src Private Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "bitcoin-core-secp256k1";
-			productName = "bitcoin-core-secp256k1";
-			productReference = 228C193C5D97130985D9AB568E3E7F86 /* bitcoin_core_secp256k1.framework */;
-			productType = "com.apple.product-type.framework";
-		};
 		43D8979194A185A71B3BFA2BD916AE61 /* Pods-VcNetworking */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = D17E8ABEE5A30D73112748EF754F5F11 /* Build configuration list for PBXNativeTarget "Pods-VcNetworking" */;
+			buildConfigurationList = A0618924D3AC61D505A359EFBA60598E /* Build configuration list for PBXNativeTarget "Pods-VcNetworking" */;
 			buildPhases = (
-				739A4CFB3EC4BA3DAC2A8EA9EB9C4B11 /* Headers */,
-				042B8296EB54F1A00C0586E1733FC111 /* Sources */,
-				94844C1F324432769564EF25E89B8E59 /* Frameworks */,
-				BD0361CDCB00A033BF9ACEB5556B4BF7 /* Resources */,
+				84F2C0988AF381A99D3B9ED593115A21 /* Headers */,
+				0049222CE55FD843F12DEB00C707D32A /* Sources */,
+				2D3C8995638500657B8B348A32619168 /* Frameworks */,
+				89A4273AF6DC3B5FA2A75732CA882284 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				3FBD2674496276F18DD315F4F5E46768 /* PBXTargetDependency */,
+				EFFEE0836DD38C46654F488F1752F019 /* PBXTargetDependency */,
 			);
 			name = "Pods-VcNetworking";
 			productName = "Pods-VcNetworking";
@@ -1298,17 +1183,17 @@
 		};
 		52FFC2C20FAAFD6B148C3CF40AD6B47C /* Pods-VcCrypto */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 91A820F94E44D35EBC04AECB9E8991D9 /* Build configuration list for PBXNativeTarget "Pods-VcCrypto" */;
+			buildConfigurationList = A4E45A72968F70C3F5F43A5EC71B9E88 /* Build configuration list for PBXNativeTarget "Pods-VcCrypto" */;
 			buildPhases = (
-				3648EA904450B7DF57C3FA7260799422 /* Headers */,
-				881469A54AE73A87C3E246D81B88E1D4 /* Sources */,
-				E59279D098079C0286CCB84D7B5F85A2 /* Frameworks */,
-				EC426B2DF860052427F7D5815097A23C /* Resources */,
+				5FCD9B86D597F5E93FF1C7A803A9489E /* Headers */,
+				9471CBD0E216EE3364CD9B0060EFB039 /* Sources */,
+				9193E9874821A4B26091052545651CCD /* Frameworks */,
+				6EACE4C87767FEF632811A7FB3879283 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				FC068209787B77B57E775FDA74BCC29F /* PBXTargetDependency */,
+				E16D24BC35BE58E50A8A228515E8E53D /* PBXTargetDependency */,
 			);
 			name = "Pods-VcCrypto";
 			productName = "Pods-VcCrypto";
@@ -1317,17 +1202,17 @@
 		};
 		5D7E2303275E26391EE83BD7F317BA41 /* Pods-VcNetworking-VcNetworkingTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 39512F69F0F69FA04524BECE0675F360 /* Build configuration list for PBXNativeTarget "Pods-VcNetworking-VcNetworkingTests" */;
+			buildConfigurationList = 4C779785E67B6EF30137ED2DBDFD4704 /* Build configuration list for PBXNativeTarget "Pods-VcNetworking-VcNetworkingTests" */;
 			buildPhases = (
-				03D1E6F1D850CAC2B2529D643C875D4A /* Headers */,
-				982EB6738A0F40A55B1FD5F153D98842 /* Sources */,
-				5A50570BF1FD18F4D708F508E7DC294E /* Frameworks */,
-				6045744A478BBACDC36AAB6BDDFBC9DB /* Resources */,
+				35B850D2943980431190C68D92EC06D9 /* Headers */,
+				D8E22E1982015BA2A219491731AF29AF /* Sources */,
+				49D2371319A8B7923527818F828B4D45 /* Frameworks */,
+				3B8F082E18859F5D57DF3CC57859E73F /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				AE11514A9A1D98FBFAB436F9E31C2297 /* PBXTargetDependency */,
+				7ACFCD03772FC4A3E89CC8991B7DB1B3 /* PBXTargetDependency */,
 			);
 			name = "Pods-VcNetworking-VcNetworkingTests";
 			productName = "Pods-VcNetworking-VcNetworkingTests";
@@ -1354,38 +1239,56 @@
 		};
 		908A5E907B992AEF4B5DB10964FBB5FC /* Pods-sdk */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = A04AFE91527CE31325EC6726B8BA8216 /* Build configuration list for PBXNativeTarget "Pods-sdk" */;
+			buildConfigurationList = 20FF90F02D0BE832C3A7DC8F774761D3 /* Build configuration list for PBXNativeTarget "Pods-sdk" */;
 			buildPhases = (
-				CB59797235B9ED6190A55D810E902F7B /* Headers */,
-				DEC2449EE906A03198C857B2D4E69BB8 /* Sources */,
-				6C247BA6765E272940925E2B84DD477A /* Frameworks */,
-				29524BF36B3DDE45D569FD8D875C8EF9 /* Resources */,
+				DDD352E261410DCC09D7989617F04347 /* Headers */,
+				9E07CECBFE3C6A432182FCF57C75A741 /* Sources */,
+				2C83921CDECA3C271821203C7E186A64 /* Frameworks */,
+				5851BB2221A36CE63EC7068265A5D3BB /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				78D796765B8BE39CB0A420E141AB20B1 /* PBXTargetDependency */,
-				746C3C51F707F9563C8B2BBF65270DA9 /* PBXTargetDependency */,
+				EC767B3213A0C5A4E775D0A775E8D3BF /* PBXTargetDependency */,
+				562655110657D3DEEBC513E436469B2B /* PBXTargetDependency */,
 			);
 			name = "Pods-sdk";
 			productName = "Pods-sdk";
 			productReference = 0421A70AF7B3109297422E3D8F394BAE /* Pods_sdk.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		C482950A93EDEEFD02D6E0B3364BC95C /* Pods-VcJwt-VcJwtTests */ = {
+		A2701971E9F776D08826CE4ABC57817F /* secp256k1_ios */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = EF6E05670007B86C5692DEC4BADB337F /* Build configuration list for PBXNativeTarget "Pods-VcJwt-VcJwtTests" */;
+			buildConfigurationList = 4500320F3844126945DB43F107FEA7CA /* Build configuration list for PBXNativeTarget "secp256k1_ios" */;
 			buildPhases = (
-				AC2203DA80B1741CA5D9837854C92B43 /* Headers */,
-				64431A09561B94CDA4BB2629EA6976F2 /* Sources */,
-				99FDB285877F506D947D169C372A3FE3 /* Frameworks */,
-				1AFE2B23C0F03EF3E32BBCF861DA4EA0 /* Resources */,
+				474F29A0F29B8DBCC6FAD58C756C9686 /* Headers */,
+				AE8E8E5BA2D82B198FFA42BEB7509270 /* Sources */,
+				B61D2F9C8FFBC67131695BF5653EF7F9 /* Frameworks */,
+				E656976FC36056AE870D7B398D3DF851 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				909AD507C83093F9CA2D7D3784D7E461 /* PBXTargetDependency */,
-				944B285E7364A5CB07877E60D2222283 /* PBXTargetDependency */,
+			);
+			name = secp256k1_ios;
+			productName = secp256k1_ios;
+			productReference = 797B7243FC6C7A8F94A8CFA9E05C458C /* secp256k1_ios.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		C482950A93EDEEFD02D6E0B3364BC95C /* Pods-VcJwt-VcJwtTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 30F89017A2296A06D8BF548857C8862D /* Build configuration list for PBXNativeTarget "Pods-VcJwt-VcJwtTests" */;
+			buildPhases = (
+				4844A6ADEB0D28232D8FE5F9062941E5 /* Headers */,
+				6D2B872C20E09ACCE5F31195174C8C78 /* Sources */,
+				AD45CFCF809EB9F6843E288CD0E119CB /* Frameworks */,
+				1A99A46186F6E58102D341797D99E625 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E2442FE1F3B54018C6EB199577EC7ACB /* PBXTargetDependency */,
+				241F53D23EBB6DF68C64A11549C5E6B0 /* PBXTargetDependency */,
 			);
 			name = "Pods-VcJwt-VcJwtTests";
 			productName = "Pods-VcJwt-VcJwtTests";
@@ -1394,18 +1297,18 @@
 		};
 		F1201D9D9F174FB23218D6347427DCD7 /* Pods-sdk-sdkTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 302FBB27D102EDB725D5228AA068B4E3 /* Build configuration list for PBXNativeTarget "Pods-sdk-sdkTests" */;
+			buildConfigurationList = 81E4FF1898115C9DD9A39734F2FCAC47 /* Build configuration list for PBXNativeTarget "Pods-sdk-sdkTests" */;
 			buildPhases = (
-				44BA0144F62D12850217D47610DC0C8A /* Headers */,
-				F513D1753DBF457AED2F9BE4C3280776 /* Sources */,
-				37F7DC58A16DA323FF0952745A9AFA03 /* Frameworks */,
-				895476880EFCAC03820FBCD3C7221563 /* Resources */,
+				ED17099A8C26F3B0130AC5AAE78326F6 /* Headers */,
+				2B1A5C585DFD1186294367989B2B3A26 /* Sources */,
+				DDC0CF0145273198FF86FD87F2F3FA18 /* Frameworks */,
+				4A213724683C41766921789F240128EF /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				EB5E76E536975C4A6EA9F9261B5358E5 /* PBXTargetDependency */,
-				9DA6B9B889002047DA0A9B822D77DF12 /* PBXTargetDependency */,
+				DA03C66E4E95B09BDAAB7AD002E23281 /* PBXTargetDependency */,
+				2859087CA92011919F363904923F452B /* PBXTargetDependency */,
 			);
 			name = "Pods-sdk-sdkTests";
 			productName = "Pods-sdk-sdkTests";
@@ -1430,11 +1333,10 @@
 				Base,
 			);
 			mainGroup = CF1408CF629C7361332E53B88F7BD30C;
-			productRefGroup = 8CCD289A063E8649185814FD38A2177B /* Products */;
+			productRefGroup = FF9C74392E7B6B62A1253A57E3F785CD /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				3020FF5BE409E86C04853BBDEF3E50A7 /* bitcoin-core-secp256k1 */,
 				908A5E907B992AEF4B5DB10964FBB5FC /* Pods-sdk */,
 				F1201D9D9F174FB23218D6347427DCD7 /* Pods-sdk-sdkTests */,
 				52FFC2C20FAAFD6B148C3CF40AD6B47C /* Pods-VcCrypto */,
@@ -1444,6 +1346,7 @@
 				43D8979194A185A71B3BFA2BD916AE61 /* Pods-VcNetworking */,
 				5D7E2303275E26391EE83BD7F317BA41 /* Pods-VcNetworking-VcNetworkingTests */,
 				7C579CE66A1E7A9AA33CA5F97F9C22C5 /* PromiseKit */,
+				A2701971E9F776D08826CE4ABC57817F /* secp256k1_ios */,
 				9AE68C3D8E67C47FB2C8E83198549C5F /* VcCrypto */,
 				37DBAFDC20E13984CC335B195F5E85D9 /* VcNetworking */,
 			);
@@ -1451,14 +1354,14 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		1AFE2B23C0F03EF3E32BBCF861DA4EA0 /* Resources */ = {
+		1A99A46186F6E58102D341797D99E625 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		29524BF36B3DDE45D569FD8D875C8EF9 /* Resources */ = {
+		3B8F082E18859F5D57DF3CC57859E73F /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1472,49 +1375,49 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		55BA245CED2D5D689E700EF85293026B /* Resources */ = {
+		4A213724683C41766921789F240128EF /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6045744A478BBACDC36AAB6BDDFBC9DB /* Resources */ = {
+		5851BB2221A36CE63EC7068265A5D3BB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		895476880EFCAC03820FBCD3C7221563 /* Resources */ = {
+		6EACE4C87767FEF632811A7FB3879283 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A1F1981C3F7BA5D94269956DEAB033D6 /* Resources */ = {
+		7DC54003C7AE571D3FA8682E8E7F04CB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BD0361CDCB00A033BF9ACEB5556B4BF7 /* Resources */ = {
+		89A4273AF6DC3B5FA2A75732CA882284 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E5C7ECF28675E84862A855355A6CD95B /* Resources */ = {
+		89DD86BC9B608D1CCE1E1730CA521681 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EC426B2DF860052427F7D5815097A23C /* Resources */ = {
+		E656976FC36056AE870D7B398D3DF851 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1524,60 +1427,62 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		042B8296EB54F1A00C0586E1733FC111 /* Sources */ = {
+		0049222CE55FD843F12DEB00C707D32A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BFD73D585DF049387B8818B7833016EC /* Pods-VcNetworking-dummy.m in Sources */,
+				BC0F7B6696E14DFB8EC79D1E071864E2 /* Pods-VcNetworking-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		278E1F7A6ECF73FFD77BD789D1F83613 /* Sources */ = {
+		2B1A5C585DFD1186294367989B2B3A26 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CC109599EB717FB4B908412C26F16850 /* Pods-VcJwt-dummy.m in Sources */,
+				99555576AD055A0859DD52D9264E4CBB /* Pods-sdk-sdkTests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		64431A09561B94CDA4BB2629EA6976F2 /* Sources */ = {
+		6D2B872C20E09ACCE5F31195174C8C78 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A2CB7D43B0511320372716A44086E9ED /* Pods-VcJwt-VcJwtTests-dummy.m in Sources */,
+				4A9B8EEB1D3196184111055D37614E1F /* Pods-VcJwt-VcJwtTests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		881469A54AE73A87C3E246D81B88E1D4 /* Sources */ = {
+		7B8EF39BB5BB472A61BAA9A98587CE93 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				26D210114481EAE30A5EB236900005CA /* Pods-VcCrypto-dummy.m in Sources */,
+				197403401F865B195517322CD447D412 /* Pods-VcJwt-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		982EB6738A0F40A55B1FD5F153D98842 /* Sources */ = {
+		9471CBD0E216EE3364CD9B0060EFB039 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				30BCA1FE6C490D5BAB5105BFEB8C6CC0 /* Pods-VcNetworking-VcNetworkingTests-dummy.m in Sources */,
+				5F855A539D5FBD16A06C124B87825957 /* Pods-VcCrypto-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B8E9CB25BA5D860E1C68C7CB65C93803 /* Sources */ = {
+		9E07CECBFE3C6A432182FCF57C75A741 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3E1B08E5A2C1E58384F075C8F653537C /* bitcoin-core-secp256k1-dummy.m in Sources */,
-				167E4B1DDE01AB1072D449721EF3572E /* secp256k1.c in Sources */,
+				EDAFD563D61F53D4C97920A42EF7895D /* Pods-sdk-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BBBA3C5F33BCD06315AD5026858DAACA /* Sources */ = {
+		AE8E8E5BA2D82B198FFA42BEB7509270 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CAD4996BF8ECBA77CD4F1AFA07EAE46B /* Pods-VcCrypto-VcCryptoTests-dummy.m in Sources */,
+				928F97F6949B4E9E6747BA327CA6D5B1 /* lax_der_parsing.c in Sources */,
+				8EAA67BB5325445D89AB40CFAAC2D8C1 /* lax_der_privatekey_parsing.c in Sources */,
+				7CB206B4966420E9AABD313CBD8AEAC7 /* secp256k1.c in Sources */,
+				3B1458841AD8CD6BCB2BFFF82FC0FBE3 /* secp256k1_ios-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1625,132 +1530,115 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DEC2449EE906A03198C857B2D4E69BB8 /* Sources */ = {
+		D8E22E1982015BA2A219491731AF29AF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5243E5D2DA9468B680129F9299F72207 /* Pods-sdk-dummy.m in Sources */,
+				8C28B448DDF7BA321701C511819A5A21 /* Pods-VcNetworking-VcNetworkingTests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F513D1753DBF457AED2F9BE4C3280776 /* Sources */ = {
+		E8AD849CA9B0EE18FC01468B1A291D0B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E4B39D3E52F5024EDD04C4BC5A19735E /* Pods-sdk-sdkTests-dummy.m in Sources */,
+				8DBBE5C3EBDBB182829890B8AAA26356 /* Pods-VcCrypto-VcCryptoTests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		3FBD2674496276F18DD315F4F5E46768 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = PromiseKit;
-			target = 7C579CE66A1E7A9AA33CA5F97F9C22C5 /* PromiseKit */;
-			targetProxy = 7F708D884864F4BE02013D4E46BDBE00 /* PBXContainerItemProxy */;
-		};
-		457FD41BF44624F76CA4B0875B50308A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "bitcoin-core-secp256k1";
-			target = 3020FF5BE409E86C04853BBDEF3E50A7 /* bitcoin-core-secp256k1 */;
-			targetProxy = A64009CE24A51E68AB404C77505A1A72 /* PBXContainerItemProxy */;
-		};
-		746C3C51F707F9563C8B2BBF65270DA9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = VcNetworking;
-			target = 37DBAFDC20E13984CC335B195F5E85D9 /* VcNetworking */;
-			targetProxy = 15FEDFFAF1E043D37DF5D7A836B6D9E3 /* PBXContainerItemProxy */;
-		};
-		78D796765B8BE39CB0A420E141AB20B1 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = PromiseKit;
-			target = 7C579CE66A1E7A9AA33CA5F97F9C22C5 /* PromiseKit */;
-			targetProxy = E3E0366F469EFA877271E0B1BDF1B6C3 /* PBXContainerItemProxy */;
-		};
-		80F8802E60139D49A0D93A471C27F28A /* PBXTargetDependency */ = {
+		0016BC81A6872DA571556C0534423C66 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = VcCrypto;
 			target = 9AE68C3D8E67C47FB2C8E83198549C5F /* VcCrypto */;
-			targetProxy = 1BC9530B95CD2CAAECCCB0E432259E49 /* PBXContainerItemProxy */;
+			targetProxy = CC30210DB30EA14FA994CFD07859FFF1 /* PBXContainerItemProxy */;
 		};
-		909AD507C83093F9CA2D7D3784D7E461 /* PBXTargetDependency */ = {
+		241F53D23EBB6DF68C64A11549C5E6B0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = VcCrypto;
-			target = 9AE68C3D8E67C47FB2C8E83198549C5F /* VcCrypto */;
-			targetProxy = 7251087F3587965D8387D0FE2E4C7DED /* PBXContainerItemProxy */;
+			name = secp256k1_ios;
+			target = A2701971E9F776D08826CE4ABC57817F /* secp256k1_ios */;
+			targetProxy = A1B7341F04D6251F408A4BE614D694BA /* PBXContainerItemProxy */;
 		};
-		92D1A94A3BEA8B3EC7386AAFB151CB66 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = PromiseKit;
-			target = 7C579CE66A1E7A9AA33CA5F97F9C22C5 /* PromiseKit */;
-			targetProxy = 6E2177128E222F1AD6BB3615CC96B60F /* PBXContainerItemProxy */;
-		};
-		944B285E7364A5CB07877E60D2222283 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "bitcoin-core-secp256k1";
-			target = 3020FF5BE409E86C04853BBDEF3E50A7 /* bitcoin-core-secp256k1 */;
-			targetProxy = 44A774CCD9F7984737025616B23E8A69 /* PBXContainerItemProxy */;
-		};
-		9C098115BD15AB16933397D88360D89A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "bitcoin-core-secp256k1";
-			target = 3020FF5BE409E86C04853BBDEF3E50A7 /* bitcoin-core-secp256k1 */;
-			targetProxy = 3F37E650BBC111E5DB58D6D8570226E7 /* PBXContainerItemProxy */;
-		};
-		9DA6B9B889002047DA0A9B822D77DF12 /* PBXTargetDependency */ = {
+		2859087CA92011919F363904923F452B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = VcNetworking;
 			target = 37DBAFDC20E13984CC335B195F5E85D9 /* VcNetworking */;
-			targetProxy = 49D91120CF23E43C39F921D865712EC6 /* PBXContainerItemProxy */;
+			targetProxy = 289B305BD9F1ABC023F45A6AF030CC3D /* PBXContainerItemProxy */;
 		};
-		A16792503F59DF4AD640772BC41D2AC1 /* PBXTargetDependency */ = {
+		5263D5668B62C71B665FF0D379D5D2D3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "bitcoin-core-secp256k1";
-			target = 3020FF5BE409E86C04853BBDEF3E50A7 /* bitcoin-core-secp256k1 */;
-			targetProxy = 16A3D9D084EE6A7ACABE07A6C7859480 /* PBXContainerItemProxy */;
+			name = secp256k1_ios;
+			target = A2701971E9F776D08826CE4ABC57817F /* secp256k1_ios */;
+			targetProxy = A5AFD41BE6CCE8C1C8F3F0FD7D286231 /* PBXContainerItemProxy */;
 		};
-		AE11514A9A1D98FBFAB436F9E31C2297 /* PBXTargetDependency */ = {
+		562655110657D3DEEBC513E436469B2B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = VcNetworking;
+			target = 37DBAFDC20E13984CC335B195F5E85D9 /* VcNetworking */;
+			targetProxy = 069B24003BF95424FDEDA5579C59ABCC /* PBXContainerItemProxy */;
+		};
+		6361D62647C5CD08886E63F303E0D509 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = PromiseKit;
 			target = 7C579CE66A1E7A9AA33CA5F97F9C22C5 /* PromiseKit */;
-			targetProxy = AB4995975A5BD79F01E8DB41F6D8ADFE /* PBXContainerItemProxy */;
+			targetProxy = 0ED169543E35C8512891EE13FF42930E /* PBXContainerItemProxy */;
 		};
-		EB5E76E536975C4A6EA9F9261B5358E5 /* PBXTargetDependency */ = {
+		7ACFCD03772FC4A3E89CC8991B7DB1B3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = PromiseKit;
 			target = 7C579CE66A1E7A9AA33CA5F97F9C22C5 /* PromiseKit */;
-			targetProxy = F6187785962DE84510431815E226833F /* PBXContainerItemProxy */;
+			targetProxy = 37006E3BD8E1AB7395F762A4E8441866 /* PBXContainerItemProxy */;
 		};
-		FC068209787B77B57E775FDA74BCC29F /* PBXTargetDependency */ = {
+		959AE62CAA75D97E225DB964AC51C965 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "bitcoin-core-secp256k1";
-			target = 3020FF5BE409E86C04853BBDEF3E50A7 /* bitcoin-core-secp256k1 */;
-			targetProxy = FE952EC7C5C84483717621FEEDABC7E3 /* PBXContainerItemProxy */;
+			name = secp256k1_ios;
+			target = A2701971E9F776D08826CE4ABC57817F /* secp256k1_ios */;
+			targetProxy = 3899DCA2E665ED9340FDF1166A4B6327 /* PBXContainerItemProxy */;
+		};
+		B72C50904DEB1A7797F7AF7067B3C2D5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = secp256k1_ios;
+			target = A2701971E9F776D08826CE4ABC57817F /* secp256k1_ios */;
+			targetProxy = 2F46C7CF33996C30CE7D18F42191290A /* PBXContainerItemProxy */;
+		};
+		DA03C66E4E95B09BDAAB7AD002E23281 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PromiseKit;
+			target = 7C579CE66A1E7A9AA33CA5F97F9C22C5 /* PromiseKit */;
+			targetProxy = E2D772DE5757C7F34F08C7263230965F /* PBXContainerItemProxy */;
+		};
+		E16D24BC35BE58E50A8A228515E8E53D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = secp256k1_ios;
+			target = A2701971E9F776D08826CE4ABC57817F /* secp256k1_ios */;
+			targetProxy = FF6A7AAC28BDDC570153D3567E130883 /* PBXContainerItemProxy */;
+		};
+		E2442FE1F3B54018C6EB199577EC7ACB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = VcCrypto;
+			target = 9AE68C3D8E67C47FB2C8E83198549C5F /* VcCrypto */;
+			targetProxy = 54C7AD8EDD3BAC400F928EDBD560C915 /* PBXContainerItemProxy */;
+		};
+		EC767B3213A0C5A4E775D0A775E8D3BF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PromiseKit;
+			target = 7C579CE66A1E7A9AA33CA5F97F9C22C5 /* PromiseKit */;
+			targetProxy = FA29145037473CDC063B6631505442BB /* PBXContainerItemProxy */;
+		};
+		EFFEE0836DD38C46654F488F1752F019 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PromiseKit;
+			target = 7C579CE66A1E7A9AA33CA5F97F9C22C5 /* PromiseKit */;
+			targetProxy = D7EEA0D182ADC386BD2B9ADA9735A579 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		11A83B1B9736855FB0A53A7D54FF2A34 /* Debug */ = {
+		03968ACACDADA1C16095C21E4C6A4913 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CC69D6B91ABDC771DF760185F03CAE94 /* VcNetworking.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		16CE6BFB060DA9130C2E6EF6E1C0AF6D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 180CFB385DEC15A7AA5DAFF7CA90138B /* Pods-sdk.debug.xcconfig */;
+			baseConfigurationReference = 3BEE82B0FED60433BF1663D6B7A368F0 /* Pods-VcCrypto-VcCryptoTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -1763,7 +1651,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-sdk/Pods-sdk-Info.plist";
+				INFOPLIST_FILE = "Target Support Files/Pods-VcCrypto-VcCryptoTests/Pods-VcCrypto-VcCryptoTests-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1772,7 +1660,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-sdk/Pods-sdk.modulemap";
+				MODULEMAP_FILE = "Target Support Files/Pods-VcCrypto-VcCryptoTests/Pods-VcCrypto-VcCryptoTests.modulemap";
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PODS_ROOT = "$(SRCROOT)";
@@ -1786,9 +1674,86 @@
 			};
 			name = Debug;
 		};
-		23913CCE14488E0FC55FF0AA1FF182D1 /* Debug */ = {
+		0A47C9741D0B2D4BF35F5E67EE3D43E3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 398CA9DBF2BCA700DB27CBC26C8213CA /* Pods-VcJwt.debug.xcconfig */;
+			baseConfigurationReference = 86A09FEBE88EA313AAD9DB9CC2B3B5C8 /* Pods-sdk-sdkTests.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests.modulemap";
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		114347D5EBAB193D6C1A04292C2CB605 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 786FCD9A3ADF8E2137058AC66DE66545 /* Pods-VcNetworking-VcNetworkingTests.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Target Support Files/Pods-VcNetworking-VcNetworkingTests/Pods-VcNetworking-VcNetworkingTests-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-VcNetworking-VcNetworkingTests/Pods-VcNetworking-VcNetworkingTests.modulemap";
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		11C86EABB9EC7920EF13618A33E45A6A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0F7776BC5D59C957737CE50CF212C748 /* Pods-VcJwt.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -1811,6 +1776,83 @@
 				);
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "Target Support Files/Pods-VcJwt/Pods-VcJwt.modulemap";
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		1E2D6D7F45D2218DE24326A2A99A9626 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 382B6C94E311CC8E1A255AE88C7C92F6 /* Pods-VcNetworking-VcNetworkingTests.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Target Support Files/Pods-VcNetworking-VcNetworkingTests/Pods-VcNetworking-VcNetworkingTests-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-VcNetworking-VcNetworkingTests/Pods-VcNetworking-VcNetworkingTests.modulemap";
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		23E8816CFAF4E36C64764B356B2E50EC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 75C18A0502EDB790D1E6C8C90918E883 /* Pods-VcNetworking.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Target Support Files/Pods-VcNetworking/Pods-VcNetworking-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-VcNetworking/Pods-VcNetworking.modulemap";
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PODS_ROOT = "$(SRCROOT)";
@@ -1884,27 +1926,45 @@
 			};
 			name = Release;
 		};
-		30A282F1ABB14B085960B58C7BE64EB6 /* Release */ = {
+		292998DB9AEA5F948EBC2255103F7185 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B0108C8CDA1A868A4984037EA9ABC4AE /* VcCrypto.xcconfig */;
+			baseConfigurationReference = 4A3312121FB6F7D6B4479466A46AD072 /* PromiseKit.release.xcconfig */;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/PromiseKit/PromiseKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/PromiseKit/PromiseKit-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
 				);
+				MODULEMAP_FILE = "Target Support Files/PromiseKit/PromiseKit.modulemap";
+				PRODUCT_MODULE_NAME = PromiseKit;
+				PRODUCT_NAME = PromiseKit;
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};
-		43C7244FAC352C47A4C55FD96CAC2FF6 /* Release */ = {
+		2F9F96C65E0659EC0E50FFC794A2DB4C /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0F7776BC5D59C957737CE50CF212C748 /* Pods-VcJwt.release.xcconfig */;
+			baseConfigurationReference = 398CA9DBF2BCA700DB27CBC26C8213CA /* Pods-VcJwt.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -1935,347 +1995,12 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		4D1FA9D66FD4EB129A4F0A550304B984 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5FF8F40C2340DF635E60E402B82715FD /* Pods-VcNetworking.release.xcconfig */;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-VcNetworking/Pods-VcNetworking-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-VcNetworking/Pods-VcNetworking.modulemap";
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		5A9B89AD532B7B100D0CEA675ACF5BC3 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E3751E48F6AC11A7D6A7189470F35481 /* bitcoin-core-secp256k1.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/bitcoin-core-secp256k1/bitcoin-core-secp256k1-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/bitcoin-core-secp256k1/bitcoin-core-secp256k1-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/bitcoin-core-secp256k1/bitcoin-core-secp256k1.modulemap";
-				PRODUCT_MODULE_NAME = bitcoin_core_secp256k1;
-				PRODUCT_NAME = bitcoin_core_secp256k1;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
 		};
-		622C09FE6801C861677616EDF9E7A045 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 062F2FD1E832F60DC72B992A028A1A82 /* Pods-VcJwt-VcJwtTests.debug.xcconfig */;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-VcJwt-VcJwtTests/Pods-VcJwt-VcJwtTests-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-VcJwt-VcJwtTests/Pods-VcJwt-VcJwtTests.modulemap";
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		6303C0C02A8FBAF01334F2F39A448333 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E3751E48F6AC11A7D6A7189470F35481 /* bitcoin-core-secp256k1.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/bitcoin-core-secp256k1/bitcoin-core-secp256k1-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/bitcoin-core-secp256k1/bitcoin-core-secp256k1-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/bitcoin-core-secp256k1/bitcoin-core-secp256k1.modulemap";
-				PRODUCT_MODULE_NAME = bitcoin_core_secp256k1;
-				PRODUCT_NAME = bitcoin_core_secp256k1;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		6349413DD6F127D42CBC5C544C613052 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B0108C8CDA1A868A4984037EA9ABC4AE /* VcCrypto.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		65E24D7446E6AAA98B659F423C4FD567 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = A9D37953BC7E8DB814B7F81CB859304E /* Pods-sdk.release.xcconfig */;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-sdk/Pods-sdk-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-sdk/Pods-sdk.modulemap";
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		7F768F98B8A21F1F4FD4365EC3E4E98B /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = CC69D6B91ABDC771DF760185F03CAE94 /* VcNetworking.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		810751377D09B9E1EC0DF4C59D0080A1 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = CBC4F120CE3B9E5CA8EB2AA34432C51E /* PromiseKit.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/PromiseKit/PromiseKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/PromiseKit/PromiseKit-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/PromiseKit/PromiseKit.modulemap";
-				PRODUCT_MODULE_NAME = PromiseKit;
-				PRODUCT_NAME = PromiseKit;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		A2D2743E101F3AE09074FBBA4C3DBD44 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3BEE82B0FED60433BF1663D6B7A368F0 /* Pods-VcCrypto-VcCryptoTests.debug.xcconfig */;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-VcCrypto-VcCryptoTests/Pods-VcCrypto-VcCryptoTests-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-VcCrypto-VcCryptoTests/Pods-VcCrypto-VcCryptoTests.modulemap";
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		A3D99D42198F88017172F5D4FD2F6345 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 753650BD30E7808C6C6AE26719790145 /* Pods-VcCrypto.release.xcconfig */;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-VcCrypto/Pods-VcCrypto-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-VcCrypto/Pods-VcCrypto.modulemap";
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		AC9E21FDA5FCDBA0FA618E489CD7E556 /* Release */ = {
+		3304DCCAC7F3CD710791FCE7DFF99B09 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5A8A488E8DB257246A94BCB49BAAA738 /* Pods-VcCrypto-VcCryptoTests.release.xcconfig */;
 			buildSettings = {
@@ -2314,7 +2039,207 @@
 			};
 			name = Release;
 		};
-		B161DD59D8430817E1F887DA51BAA3E6 /* Debug */ = {
+		639596FE9560C61C9E508822872747AD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 180CFB385DEC15A7AA5DAFF7CA90138B /* Pods-sdk.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Target Support Files/Pods-sdk/Pods-sdk-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-sdk/Pods-sdk.modulemap";
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		7942D7B6B4E832C6FE5D860DE8995EB3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F3C317F718A42143149D0B6A88B56DCD /* VcNetworking.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A39281833B334921311F257745C9F168 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A9D37953BC7E8DB814B7F81CB859304E /* Pods-sdk.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Target Support Files/Pods-sdk/Pods-sdk-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-sdk/Pods-sdk.modulemap";
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		B143110717EBC9F38F12AC7E7D725364 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B59C04F48A9014381511F9623105A875 /* PromiseKit.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/PromiseKit/PromiseKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/PromiseKit/PromiseKit-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/PromiseKit/PromiseKit.modulemap";
+				PRODUCT_MODULE_NAME = PromiseKit;
+				PRODUCT_NAME = PromiseKit;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		B2813782D1C56D3E1F3D32C6B5B8548F /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C31433B9FC270C8D03B007BF97EA5C22 /* secp256k1_ios.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/secp256k1_ios/secp256k1_ios-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/secp256k1_ios/secp256k1_ios-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/secp256k1_ios/secp256k1_ios.modulemap";
+				PRODUCT_MODULE_NAME = secp256k1_ios;
+				PRODUCT_NAME = secp256k1_ios;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		C2EB9134638C3C921A4BD203CED75C8A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FAE13A4D4D22D7C0B347EE84F1E24B3B /* secp256k1_ios.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/secp256k1_ios/secp256k1_ios-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/secp256k1_ios/secp256k1_ios-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/secp256k1_ios/secp256k1_ios.modulemap";
+				PRODUCT_MODULE_NAME = secp256k1_ios;
+				PRODUCT_NAME = secp256k1_ios;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		C676E49663D2FAEA0833AFC1F9307987 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 07EAED9DE7C9C6F3FE2BD665FEA7BDE3 /* Pods-VcCrypto.debug.xcconfig */;
 			buildSettings = {
@@ -2352,9 +2277,9 @@
 			};
 			name = Debug;
 		};
-		B8455EE3E43DD956A3ACF1A67FFB6CBD /* Debug */ = {
+		D2005A72A60A1396AC7A4FFC54FF4CDC /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 75C18A0502EDB790D1E6C8C90918E883 /* Pods-VcNetworking.debug.xcconfig */;
+			baseConfigurationReference = 5FF8F40C2340DF635E60E402B82715FD /* Pods-VcNetworking.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -2385,89 +2310,31 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		C0481FBF7BA4DAB910EBC684DE820E3D /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4DF8D04C1F5CBE76FF631A0B4F81FB5E /* Pods-sdk-sdkTests.release.xcconfig */;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests.modulemap";
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};
-		C94F6FC5E8D39A4909964A4167EA008D /* Debug */ = {
+		D6E82D2B6DB5F808C5F2930771A8FD9C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 86A09FEBE88EA313AAD9DB9CC2B3B5C8 /* Pods-sdk-sdkTests.debug.xcconfig */;
+			baseConfigurationReference = 6CB79A2F18EFFE2B528DD29DE55DCC66 /* VcCrypto.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
 				);
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests.modulemap";
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
+				VALIDATE_PRODUCT = YES;
 			};
-			name = Debug;
+			name = Release;
 		};
-		DBDFE9733404950655944AABF893CF49 /* Release */ = {
+		DBA3533165A99985E6844592084843C2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B6EC27AA2CAA5B28A8C123E4E8A03D79 /* Pods-VcJwt-VcJwtTests.release.xcconfig */;
 			buildSettings = {
@@ -2505,44 +2372,6 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
-		};
-		DD8906C7B63140AA08F8DE52E1480948 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 382B6C94E311CC8E1A255AE88C7C92F6 /* Pods-VcNetworking-VcNetworkingTests.debug.xcconfig */;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-VcNetworking-VcNetworkingTests/Pods-VcNetworking-VcNetworkingTests-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-VcNetworking-VcNetworkingTests/Pods-VcNetworking-VcNetworkingTests.modulemap";
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
 		};
 		DD8F832993327D1DD8046C3CBCBD97CD /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -2608,9 +2437,9 @@
 			};
 			name = Debug;
 		};
-		E294ED01D2112C49E7B9783BE95FCB34 /* Release */ = {
+		E1F7077360BDAA29FBF5B2FF15A794CF /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 786FCD9A3ADF8E2137058AC66DE66545 /* Pods-VcNetworking-VcNetworkingTests.release.xcconfig */;
+			baseConfigurationReference = 4DF8D04C1F5CBE76FF631A0B4F81FB5E /* Pods-sdk-sdkTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -2623,7 +2452,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-VcNetworking-VcNetworkingTests/Pods-VcNetworking-VcNetworkingTests-Info.plist";
+				INFOPLIST_FILE = "Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2632,7 +2461,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-VcNetworking-VcNetworkingTests/Pods-VcNetworking-VcNetworkingTests.modulemap";
+				MODULEMAP_FILE = "Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests.modulemap";
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PODS_ROOT = "$(SRCROOT)";
@@ -2647,10 +2476,12 @@
 			};
 			name = Release;
 		};
-		E4B377AE77F1821330F7166C808972CB /* Release */ = {
+		EF28113938957AA7CB10CBC0B4CA7A96 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CBC4F120CE3B9E5CA8EB2AA34432C51E /* PromiseKit.xcconfig */;
+			baseConfigurationReference = 062F2FD1E832F60DC72B992A028A1A82 /* Pods-VcJwt-VcJwtTests.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2660,22 +2491,61 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/PromiseKit/PromiseKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/PromiseKit/PromiseKit-Info.plist";
+				INFOPLIST_FILE = "Target Support Files/Pods-VcJwt-VcJwtTests/Pods-VcJwt-VcJwtTests-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MODULEMAP_FILE = "Target Support Files/PromiseKit/PromiseKit.modulemap";
-				PRODUCT_MODULE_NAME = PromiseKit;
-				PRODUCT_NAME = PromiseKit;
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-VcJwt-VcJwtTests/Pods-VcJwt-VcJwtTests.modulemap";
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		EFCA414EE2B5A2373D77DD374C65F8D3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 753650BD30E7808C6C6AE26719790145 /* Pods-VcCrypto.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Target Support Files/Pods-VcCrypto/Pods-VcCrypto-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-VcCrypto/Pods-VcCrypto.modulemap";
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -2683,32 +2553,76 @@
 			};
 			name = Release;
 		};
+		F1643D4F45388C4057BE2CD9EFBCE2EB /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CB8C9C6F8211787F2948D4A834A63619 /* VcNetworking.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		F92CEFE507D77FB45E8A81C5CAA99727 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9839460CCEC6354E3D6F4B1D9A9EA615 /* VcCrypto.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
 		058DF38F5922F24842B97693B0188F2D /* Build configuration list for PBXNativeTarget "PromiseKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				810751377D09B9E1EC0DF4C59D0080A1 /* Debug */,
-				E4B377AE77F1821330F7166C808972CB /* Release */,
+				B143110717EBC9F38F12AC7E7D725364 /* Debug */,
+				292998DB9AEA5F948EBC2255103F7185 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		302FBB27D102EDB725D5228AA068B4E3 /* Build configuration list for PBXNativeTarget "Pods-sdk-sdkTests" */ = {
+		20FF90F02D0BE832C3A7DC8F774761D3 /* Build configuration list for PBXNativeTarget "Pods-sdk" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				C94F6FC5E8D39A4909964A4167EA008D /* Debug */,
-				C0481FBF7BA4DAB910EBC684DE820E3D /* Release */,
+				639596FE9560C61C9E508822872747AD /* Debug */,
+				A39281833B334921311F257745C9F168 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		39512F69F0F69FA04524BECE0675F360 /* Build configuration list for PBXNativeTarget "Pods-VcNetworking-VcNetworkingTests" */ = {
+		30F89017A2296A06D8BF548857C8862D /* Build configuration list for PBXNativeTarget "Pods-VcJwt-VcJwtTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				DD8906C7B63140AA08F8DE52E1480948 /* Debug */,
-				E294ED01D2112C49E7B9783BE95FCB34 /* Release */,
+				EF28113938957AA7CB10CBC0B4CA7A96 /* Debug */,
+				DBA3533165A99985E6844592084843C2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4500320F3844126945DB43F107FEA7CA /* Build configuration list for PBXNativeTarget "secp256k1_ios" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C2EB9134638C3C921A4BD203CED75C8A /* Debug */,
+				B2813782D1C56D3E1F3D32C6B5B8548F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -2722,83 +2636,74 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		69A1FDE87F3A343E85BF3137B1130788 /* Build configuration list for PBXNativeTarget "Pods-VcCrypto-VcCryptoTests" */ = {
+		4C779785E67B6EF30137ED2DBDFD4704 /* Build configuration list for PBXNativeTarget "Pods-VcNetworking-VcNetworkingTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A2D2743E101F3AE09074FBBA4C3DBD44 /* Debug */,
-				AC9E21FDA5FCDBA0FA618E489CD7E556 /* Release */,
+				1E2D6D7F45D2218DE24326A2A99A9626 /* Debug */,
+				114347D5EBAB193D6C1A04292C2CB605 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		91A820F94E44D35EBC04AECB9E8991D9 /* Build configuration list for PBXNativeTarget "Pods-VcCrypto" */ = {
+		5E3AF5E3D41514F64AA40EDD0C5F6449 /* Build configuration list for PBXNativeTarget "Pods-VcCrypto-VcCryptoTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B161DD59D8430817E1F887DA51BAA3E6 /* Debug */,
-				A3D99D42198F88017172F5D4FD2F6345 /* Release */,
+				03968ACACDADA1C16095C21E4C6A4913 /* Debug */,
+				3304DCCAC7F3CD710791FCE7DFF99B09 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		9216F241A7F28247C884C8E5849B0204 /* Build configuration list for PBXNativeTarget "bitcoin-core-secp256k1" */ = {
+		6381A2B4D87ED43A9681692F3DE751B3 /* Build configuration list for PBXNativeTarget "Pods-VcJwt" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5A9B89AD532B7B100D0CEA675ACF5BC3 /* Debug */,
-				6303C0C02A8FBAF01334F2F39A448333 /* Release */,
+				2F9F96C65E0659EC0E50FFC794A2DB4C /* Debug */,
+				11C86EABB9EC7920EF13618A33E45A6A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		9E2153A753C83B116C4FB14BC1F849FB /* Build configuration list for PBXNativeTarget "Pods-VcJwt" */ = {
+		81E4FF1898115C9DD9A39734F2FCAC47 /* Build configuration list for PBXNativeTarget "Pods-sdk-sdkTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				23913CCE14488E0FC55FF0AA1FF182D1 /* Debug */,
-				43C7244FAC352C47A4C55FD96CAC2FF6 /* Release */,
+				0A47C9741D0B2D4BF35F5E67EE3D43E3 /* Debug */,
+				E1F7077360BDAA29FBF5B2FF15A794CF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		A04AFE91527CE31325EC6726B8BA8216 /* Build configuration list for PBXNativeTarget "Pods-sdk" */ = {
+		9487088F46F954A7C841634987900DF3 /* Build configuration list for PBXAggregateTarget "VcNetworking" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				16CE6BFB060DA9130C2E6EF6E1C0AF6D /* Debug */,
-				65E24D7446E6AAA98B659F423C4FD567 /* Release */,
+				7942D7B6B4E832C6FE5D860DE8995EB3 /* Debug */,
+				F1643D4F45388C4057BE2CD9EFBCE2EB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		CAA64A672A550FF145510D88447DC586 /* Build configuration list for PBXAggregateTarget "VcCrypto" */ = {
+		A0618924D3AC61D505A359EFBA60598E /* Build configuration list for PBXNativeTarget "Pods-VcNetworking" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				6349413DD6F127D42CBC5C544C613052 /* Debug */,
-				30A282F1ABB14B085960B58C7BE64EB6 /* Release */,
+				23E8816CFAF4E36C64764B356B2E50EC /* Debug */,
+				D2005A72A60A1396AC7A4FFC54FF4CDC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D17E8ABEE5A30D73112748EF754F5F11 /* Build configuration list for PBXNativeTarget "Pods-VcNetworking" */ = {
+		A4E45A72968F70C3F5F43A5EC71B9E88 /* Build configuration list for PBXNativeTarget "Pods-VcCrypto" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B8455EE3E43DD956A3ACF1A67FFB6CBD /* Debug */,
-				4D1FA9D66FD4EB129A4F0A550304B984 /* Release */,
+				C676E49663D2FAEA0833AFC1F9307987 /* Debug */,
+				EFCA414EE2B5A2373D77DD374C65F8D3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		E08137701D42A2C81C217984B7CCABBD /* Build configuration list for PBXAggregateTarget "VcNetworking" */ = {
+		FCCA7B74C4EA671D22599261E597A2B0 /* Build configuration list for PBXAggregateTarget "VcCrypto" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				11A83B1B9736855FB0A53A7D54FF2A34 /* Debug */,
-				7F768F98B8A21F1F4FD4365EC3E4E98B /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		EF6E05670007B86C5692DEC4BADB337F /* Build configuration list for PBXNativeTarget "Pods-VcJwt-VcJwtTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				622C09FE6801C861677616EDF9E7A045 /* Debug */,
-				DBDFE9733404950655944AABF893CF49 /* Release */,
+				F92CEFE507D77FB45E8A81C5CAA99727 /* Debug */,
+				D6E82D2B6DB5F808C5F2930771A8FD9C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/sdk/sdk.xcodeproj/project.pbxproj
+++ b/sdk/sdk.xcodeproj/project.pbxproj
@@ -7,12 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		256DBDBB97D9B6BDDE1CDED3 /* Pods_sdk_sdkTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80EE9C71A9CCC0ECE96CE855 /* Pods_sdk_sdkTests.framework */; };
+		259D4DF008E904372EF72BFB /* Pods_sdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 464B51A2A6A3C21C5F60C57B /* Pods_sdk.framework */; };
 		55CED16324D30B9600A2AAE2 /* Podfile in Resources */ = {isa = PBXBuildFile; fileRef = 55D7C01024C89F5F0090F495 /* Podfile */; };
 		55D1C0C124C23408002A58F9 /* sdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55D1C0B724C23408002A58F9 /* sdk.framework */; };
 		55D1C0C824C23408002A58F9 /* sdk.h in Headers */ = {isa = PBXBuildFile; fileRef = 55D1C0BA24C23408002A58F9 /* sdk.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55D7C01124C89F5F0090F495 /* Podfile in Resources */ = {isa = PBXBuildFile; fileRef = 55D7C01024C89F5F0090F495 /* Podfile */; };
-		E7154C6E681CE9945F5443AF /* Pods_sdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60824ABA92552E4530F18A71 /* Pods_sdk.framework */; };
+		6AB852B71C239AC5631E5045 /* Pods_sdk_sdkTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D61EA906C96BF12198E794F /* Pods_sdk_sdkTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -26,8 +26,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		3AE051017876702045DB980C /* Pods-sdk-sdkTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sdk-sdkTests.debug.xcconfig"; path = "Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests.debug.xcconfig"; sourceTree = "<group>"; };
-		4BA4601359EA258871BAD352 /* Pods-sdk-sdkTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sdk-sdkTests.release.xcconfig"; path = "Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests.release.xcconfig"; sourceTree = "<group>"; };
+		0A951A55C99DB971916C3E46 /* Pods-sdk-sdkTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sdk-sdkTests.release.xcconfig"; path = "Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests.release.xcconfig"; sourceTree = "<group>"; };
+		1D61EA906C96BF12198E794F /* Pods_sdk_sdkTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_sdk_sdkTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		464B51A2A6A3C21C5F60C57B /* Pods_sdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_sdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		55D1C0B724C23408002A58F9 /* sdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = sdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		55D1C0BA24C23408002A58F9 /* sdk.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sdk.h; sourceTree = "<group>"; };
 		55D1C0BB24C23408002A58F9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -35,10 +36,9 @@
 		55D1C0C724C23408002A58F9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		55D7C00824C4D6130090F495 /* networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		55D7C01024C89F5F0090F495 /* Podfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		60824ABA92552E4530F18A71 /* Pods_sdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_sdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		74EB80819BBB3108427F2027 /* Pods-sdk.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sdk.debug.xcconfig"; path = "Target Support Files/Pods-sdk/Pods-sdk.debug.xcconfig"; sourceTree = "<group>"; };
-		80EE9C71A9CCC0ECE96CE855 /* Pods_sdk_sdkTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_sdk_sdkTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		8CFDE10728047D1B7A38D300 /* Pods-sdk.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sdk.release.xcconfig"; path = "Target Support Files/Pods-sdk/Pods-sdk.release.xcconfig"; sourceTree = "<group>"; };
+		B8B5E9CF475F42BF7C640871 /* Pods-sdk-sdkTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sdk-sdkTests.debug.xcconfig"; path = "Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests.debug.xcconfig"; sourceTree = "<group>"; };
+		C3D8FB2584CB011B9C61729B /* Pods-sdk.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sdk.debug.xcconfig"; path = "Target Support Files/Pods-sdk/Pods-sdk.debug.xcconfig"; sourceTree = "<group>"; };
+		F4F9106259DA811DE4BD3D40 /* Pods-sdk.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sdk.release.xcconfig"; path = "Target Support Files/Pods-sdk/Pods-sdk.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -46,7 +46,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E7154C6E681CE9945F5443AF /* Pods_sdk.framework in Frameworks */,
+				259D4DF008E904372EF72BFB /* Pods_sdk.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -55,7 +55,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				55D1C0C124C23408002A58F9 /* sdk.framework in Frameworks */,
-				256DBDBB97D9B6BDDE1CDED3 /* Pods_sdk_sdkTests.framework in Frameworks */,
+				6AB852B71C239AC5631E5045 /* Pods_sdk_sdkTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -103,10 +103,10 @@
 		7326AA8372742E638364241C /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				74EB80819BBB3108427F2027 /* Pods-sdk.debug.xcconfig */,
-				8CFDE10728047D1B7A38D300 /* Pods-sdk.release.xcconfig */,
-				3AE051017876702045DB980C /* Pods-sdk-sdkTests.debug.xcconfig */,
-				4BA4601359EA258871BAD352 /* Pods-sdk-sdkTests.release.xcconfig */,
+				C3D8FB2584CB011B9C61729B /* Pods-sdk.debug.xcconfig */,
+				F4F9106259DA811DE4BD3D40 /* Pods-sdk.release.xcconfig */,
+				B8B5E9CF475F42BF7C640871 /* Pods-sdk-sdkTests.debug.xcconfig */,
+				0A951A55C99DB971916C3E46 /* Pods-sdk-sdkTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -115,8 +115,8 @@
 			isa = PBXGroup;
 			children = (
 				55D7C00824C4D6130090F495 /* networking.framework */,
-				60824ABA92552E4530F18A71 /* Pods_sdk.framework */,
-				80EE9C71A9CCC0ECE96CE855 /* Pods_sdk_sdkTests.framework */,
+				464B51A2A6A3C21C5F60C57B /* Pods_sdk.framework */,
+				1D61EA906C96BF12198E794F /* Pods_sdk_sdkTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -139,7 +139,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 55D1C0CB24C23408002A58F9 /* Build configuration list for PBXNativeTarget "sdk" */;
 			buildPhases = (
-				8FF5AA5C9EE3DCE5EF2B2A46 /* [CP] Check Pods Manifest.lock */,
+				5E8DE7F4BA760BDE8DCB1516 /* [CP] Check Pods Manifest.lock */,
 				55D1C0B224C23408002A58F9 /* Headers */,
 				55D1C0B324C23408002A58F9 /* Sources */,
 				55D1C0B424C23408002A58F9 /* Frameworks */,
@@ -158,11 +158,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 55D1C0CE24C23408002A58F9 /* Build configuration list for PBXNativeTarget "sdkTests" */;
 			buildPhases = (
-				F9E694DE24A13375243B5CD8 /* [CP] Check Pods Manifest.lock */,
+				E940EDC9F7331B0E407AC7EC /* [CP] Check Pods Manifest.lock */,
 				55D1C0BC24C23408002A58F9 /* Sources */,
 				55D1C0BD24C23408002A58F9 /* Frameworks */,
 				55D1C0BE24C23408002A58F9 /* Resources */,
-				32F0681DBE2AFFAFEE58836E /* [CP] Embed Pods Frameworks */,
+				6077D7401F43AE5B82765365 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -232,24 +232,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		32F0681DBE2AFFAFEE58836E /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8FF5AA5C9EE3DCE5EF2B2A46 /* [CP] Check Pods Manifest.lock */ = {
+		5E8DE7F4BA760BDE8DCB1516 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -271,7 +254,24 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F9E694DE24A13375243B5CD8 /* [CP] Check Pods Manifest.lock */ = {
+		6077D7401F43AE5B82765365 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-sdk-sdkTests/Pods-sdk-sdkTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E940EDC9F7331B0E407AC7EC /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -443,7 +443,7 @@
 		};
 		55D1C0CC24C23408002A58F9 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 74EB80819BBB3108427F2027 /* Pods-sdk.debug.xcconfig */;
+			baseConfigurationReference = C3D8FB2584CB011B9C61729B /* Pods-sdk.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
@@ -472,7 +472,7 @@
 		};
 		55D1C0CD24C23408002A58F9 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8CFDE10728047D1B7A38D300 /* Pods-sdk.release.xcconfig */;
+			baseConfigurationReference = F4F9106259DA811DE4BD3D40 /* Pods-sdk.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
@@ -500,7 +500,7 @@
 		};
 		55D1C0CF24C23408002A58F9 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3AE051017876702045DB980C /* Pods-sdk-sdkTests.debug.xcconfig */;
+			baseConfigurationReference = B8B5E9CF475F42BF7C640871 /* Pods-sdk-sdkTests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = UBF8T346G9;
@@ -519,7 +519,7 @@
 		};
 		55D1C0D024C23408002A58F9 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4BA4601359EA258871BAD352 /* Pods-sdk-sdkTests.release.xcconfig */;
+			baseConfigurationReference = 0A951A55C99DB971916C3E46 /* Pods-sdk-sdkTests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = UBF8T346G9;


### PR DESCRIPTION
**Problem:**
The pod that we were using is excluding all files that have "test" in the name. This is causing a build issue because secp256k1.c has a reference to selftest.h.


**Solution:**
Fixed it by using a diferent cocoapod that also points to bitcoin-core/secp256k1 that is not filtering our that file.

**Validation:**
Ran unit tests


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
