### PR TITLE
Fix EXC_BAD_ACCESS bug

### DIFF
--- a/VcJwt/VcJwt/Header.swift
+++ b/VcJwt/VcJwt/Header.swift
@@ -8,6 +8,13 @@ public struct Header: Codable {
     public let algorithm: String?
     public let jsonWebKey: String?
     public let keyId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case type = "typ"
+        case algorithm = "alg"
+        case jsonWebKey = "jwk"
+        case keyId = "kid"
+    }
     
     public init(type: String? = nil,
                 algorithm: String? = nil,
@@ -18,11 +25,22 @@ public struct Header: Codable {
         self.jsonWebKey = jsonWebKey
         self.keyId = keyId
     }
-    
-    enum CodingKeys: String, CodingKey {
-        case type = "typ"
-        case algorithm = "alg"
-        case jsonWebKey = "jwk"
-        case keyId = "kid"
+
+    // Note: implementing decode and encode to work around a compiler issue causing a EXC_BAD_ACCESS.
+    // See: https://bugs.swift.org/browse/SR-7090
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        type = try values.decodeIfPresent(String.self, forKey: .type)
+        algorithm = try values.decodeIfPresent(String.self, forKey: .algorithm)
+        jsonWebKey = try values.decodeIfPresent(String.self, forKey: .jsonWebKey)
+        keyId = try values.decodeIfPresent(String.self, forKey: .keyId)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(algorithm, forKey: .algorithm)
+        try container.encodeIfPresent(jsonWebKey, forKey: .jsonWebKey)
+        try container.encodeIfPresent(keyId, forKey: .keyId)
     }
 }


### PR DESCRIPTION
**Problem:**
On release build we get a EXC_BAD_ACCESS crash when decoding the the data.

**Solution:**
This is due to a compiler bug. Added the encode implementation as per recommendation.


**Validation:**
Manual + unit tests


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
