### PR TITLE
Add URLSession to inits in Service layer

### DIFF
--- a/VCServices/VCServices/ExchangeService.swift
+++ b/VCServices/VCServices/ExchangeService.swift
@@ -13,9 +13,11 @@ class ExchangeService {
     private let formatter: ExchangeRequestFormatting
     private let apiCalls: ExchangeNetworking
     
-    convenience init(correlationVector: CorrelationHeader? = nil) {
+    convenience init(correlationVector: CorrelationHeader? = nil,
+                     urlSession: URLSession = URLSession.shared) {
         self.init(formatter: ExchangeRequestFormatter(),
-                  apiCalls: ExchangeNetworkCalls(correlationVector: correlationVector))
+                  apiCalls: ExchangeNetworkCalls(correlationVector: correlationVector,
+                                                 urlSession: urlSession))
     }
     
     init(formatter: ExchangeRequestFormatting,

--- a/VCServices/VCServices/IssuanceService.swift
+++ b/VCServices/VCServices/IssuanceService.swift
@@ -23,12 +23,16 @@ public class IssuanceService {
     let linkedDomainService: LinkedDomainService
     let sdkLog: VCSDKLog
     
-    public convenience init(correlationVector: CorrelationHeader? = nil) {
+    public convenience init(correlationVector: CorrelationHeader? = nil,
+                            urlSession: URLSession = URLSession.shared) {
         self.init(formatter: IssuanceResponseFormatter(),
-                  apiCalls: IssuanceNetworkCalls(correlationVector: correlationVector),
+                  apiCalls: IssuanceNetworkCalls(correlationVector: correlationVector,
+                                                 urlSession: urlSession),
                   identifierService: IdentifierService(),
-                  linkedDomainService: LinkedDomainService(correlationVector: correlationVector),
-                  pairwiseService: PairwiseService(correlationVector: correlationVector),
+                  linkedDomainService: LinkedDomainService(correlationVector: correlationVector,
+                                                           urlSession: urlSession),
+                  pairwiseService: PairwiseService(correlationVector: correlationVector,
+                                                   urlSession: urlSession),
                   sdkLog: VCSDKLog.sharedInstance)
     }
     

--- a/VCServices/VCServices/LinkedDomainService.swift
+++ b/VCServices/VCServices/LinkedDomainService.swift
@@ -13,9 +13,12 @@ class LinkedDomainService {
     private let wellKnownDocumentApiCalls: WellKnownConfigDocumentNetworking
     private let validator: DomainLinkageCredentialValidating
     
-    public convenience init(correlationVector: CorrelationHeader? = nil) {
-        self.init(didDocumentDiscoveryApiCalls: DIDDocumentNetworkCalls(correlationVector: correlationVector),
-                  wellKnownDocumentApiCalls: WellKnownConfigDocumentNetworkCalls(correlationVector: correlationVector),
+    public convenience init(correlationVector: CorrelationHeader? = nil,
+                            urlSession: URLSession = URLSession.shared) {
+        self.init(didDocumentDiscoveryApiCalls: DIDDocumentNetworkCalls(correlationVector: correlationVector,
+                                                                        urlSession: urlSession),
+                  wellKnownDocumentApiCalls: WellKnownConfigDocumentNetworkCalls(correlationVector: correlationVector,
+                                                                                 urlSession: urlSession),
                   domainLinkageValidator: DomainLinkageCredentialValidator())
     }
     

--- a/VCServices/VCServices/PairwiseService.swift
+++ b/VCServices/VCServices/PairwiseService.swift
@@ -12,8 +12,10 @@ class PairwiseService {
     private let exchangeService: ExchangeService
     private let identifierService: IdentifierService
     
-    convenience init(correlationVector: CorrelationHeader? = nil) {
-        self.init(exchangeService: ExchangeService(correlationVector: correlationVector),
+    convenience init(correlationVector: CorrelationHeader? = nil,
+                     urlSession: URLSession = URLSession.shared) {
+        self.init(exchangeService: ExchangeService(correlationVector: correlationVector,
+                                                   urlSession: urlSession),
                   identifierService: IdentifierService())
     }
     

--- a/VCServices/VCServices/PresentationService.swift
+++ b/VCServices/VCServices/PresentationService.swift
@@ -26,18 +26,21 @@ public class PresentationService {
     let linkedDomainService: LinkedDomainService
     let identifierService: IdentifierService
     let pairwiseService: PairwiseService
-    var correlationVector: CorrelationHeader?
     let sdkLog: VCSDKLog
     
-    public convenience init(correlationVector: CorrelationHeader? = nil) {
+    public convenience init(correlationVector: CorrelationHeader? = nil,
+                            urlSession: URLSession = URLSession.shared) {
         self.init(formatter: PresentationResponseFormatter(),
-                  presentationApiCalls: PresentationNetworkCalls(correlationVector: correlationVector),
-                  didDocumentDiscoveryApiCalls: DIDDocumentNetworkCalls(correlationVector: correlationVector),
+                  presentationApiCalls: PresentationNetworkCalls(correlationVector: correlationVector,
+                                                                 urlSession: urlSession),
+                  didDocumentDiscoveryApiCalls: DIDDocumentNetworkCalls(correlationVector: correlationVector,
+                                                                        urlSession: urlSession),
                   requestValidator: PresentationRequestValidator(),
-                  linkedDomainService: LinkedDomainService(correlationVector: correlationVector),
+                  linkedDomainService: LinkedDomainService(correlationVector: correlationVector,
+                                                           urlSession: urlSession),
                   identifierService: IdentifierService(),
-                  pairwiseService: PairwiseService(correlationVector: correlationVector),
-                  correlationVector: correlationVector,
+                  pairwiseService: PairwiseService(correlationVector: correlationVector,
+                                                   urlSession: urlSession),
                   sdkLog: VCSDKLog.sharedInstance)
     }
     
@@ -48,7 +51,6 @@ public class PresentationService {
          linkedDomainService: LinkedDomainService,
          identifierService: IdentifierService,
          pairwiseService: PairwiseService,
-         correlationVector: CorrelationHeader? = nil,
          sdkLog: VCSDKLog = VCSDKLog.sharedInstance) {
         self.formatter = formatter
         self.presentationApiCalls = presentationApiCalls
@@ -57,7 +59,6 @@ public class PresentationService {
         self.linkedDomainService = linkedDomainService
         self.identifierService = identifierService
         self.pairwiseService = pairwiseService
-        self.correlationVector = correlationVector
         self.sdkLog = sdkLog
     }
     


### PR DESCRIPTION
**Problem:**
We need a way for the developer to configure their own URLSession.


**Solution:**
Added URLSession param to Service initializers.


**Validation:**
Works E2E


**Type of change:**
- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.
