### PR TITLE
Clean up NetworkOperation

### DIFF
--- a/VCEntities/VCEntities/presentation/PresentationResponseContainer.swift
+++ b/VCEntities/VCEntities/presentation/PresentationResponseContainer.swift
@@ -18,7 +18,7 @@ public struct PresentationResponseContainer: ResponseContaining {
     
     public init(from presentationRequest: PresentationRequest, expiryInSeconds exp: Int = 3000) throws {
         
-        guard let aud = presentationRequest.content.redirectURI,
+        guard let aud = presentationRequest.content.clientID,
             let did = presentationRequest.content.issuer else {
                 throw PresentationResponseError.noAudienceSpecifiedInRequest
         }

--- a/VcNetworking/VcNetworking/operations/NetworkOperation.swift
+++ b/VcNetworking/VcNetworking/operations/NetworkOperation.swift
@@ -25,6 +25,7 @@ protocol InternalOperation {
     var urlSession: URLSession { get }
     var urlRequest: URLRequest { get set }
     var correlationVector: CorrelationHeader? { get set }
+    var sdkLog: VCSDKLog { get }
 }
 
 extension InternalNetworkOperation {
@@ -41,14 +42,8 @@ extension InternalNetworkOperation {
         return NoRetry()
     }
     
-    var urlSession: URLSession {
-        let session = URLSession.shared
-        
-        if VCSDKConfiguration.sharedInstance.userAgentInfo != "" {
-            session.configuration.httpAdditionalHeaders = [Constants.USER_AGENT: VCSDKConfiguration.sharedInstance.userAgentInfo]
-        }
-        
-        return session
+    var sdkLog: VCSDKLog {
+        return VCSDKLog.sharedInstance
     }
     
     public mutating func fire() -> Promise<ResponseBody> {
@@ -57,6 +52,7 @@ extension InternalNetworkOperation {
             let incrementedValue = cv.update()
             urlRequest.setValue(incrementedValue, forHTTPHeaderField: cv.name)
             
+            sdkLog.logInfo(message: "Correlation Vector for \(String(describing: self)): \(cv.value)")
         }
         
         return firstly {


### PR DESCRIPTION
**Problem:**
* Use client_id instead of redirect_uri as url to send presentation response to
* Clean up URLSession property in NetworkOperation
* Log correlation vector.


**Solution:**
Used library A to complete scenario X with quality and style.


**Validation:**
Please include here how it was verified that the PR works as intended.


**Type of change:**
- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.
