### PR TITLE
Make the pin optional for issuer idtokens

### DIFF
--- a/VCEntities/VCEntities/formatters/IssuanceResponseFormatter.swift
+++ b/VCEntities/VCEntities/formatters/IssuanceResponseFormatter.swift
@@ -80,13 +80,15 @@ public class IssuanceResponseFormatter: IssuanceResponseFormatting {
                 selfIssuedMap = [:]
             }
             selfIssuedMap?[VCEntitiesConstants.PIN] = response.issuancePin
-            
+        }
+
+        if response.issuanceIdToken != nil {
             if idTokenMap == nil {
                 idTokenMap = [:]
             }
             idTokenMap?[VCEntitiesConstants.SELF_ISSUED] = response.issuanceIdToken
         }
-        
+
         var presentationsMap: [String: String]? = nil
         if !response.requestVCMap.isEmpty {
             presentationsMap = try self.createPresentations(from: response, usingIdentifier: identifier, andSignWith: key)

--- a/VCEntities/VCEntities/presentation/PresentationRequest.swift
+++ b/VCEntities/VCEntities/presentation/PresentationRequest.swift
@@ -20,7 +20,7 @@ public struct PresentationRequest {
     }
     
     public func getPinRequiredLength() -> Int? {
-        return token.content.idTokenHint?.token.content.pin.length
+        return token.content.idTokenHint?.token.content.pin?.length
     }
     
     public func containsRequiredClaims() -> Bool {

--- a/VCEntities/VCEntities/presentation/claims/issuerIdTokenClaims/IssuerIdTokenClaims.swift
+++ b/VCEntities/VCEntities/presentation/claims/issuerIdTokenClaims/IssuerIdTokenClaims.swift
@@ -6,5 +6,5 @@
 import VCJwt
 
 public struct IssuerIdTokenClaims: Claims {
-    public let pin: PinDescriptor
+    public let pin: PinDescriptor?
 }


### PR DESCRIPTION
**Problem:**
The pin was required, but issuer may chose to not include it. When it happened, the id token was missing in the issuance response.

**Solution:**
Made the pin optional

**Validation:**
Manual


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
