### PR TITLE
Add Network Metrics

### DIFF
--- a/VCEntities/VCEntities.xcodeproj/project.pbxproj
+++ b/VCEntities/VCEntities.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		559FCA3C25CA03D200737F14 /* IssuanceRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 559FCA3B25CA03D200737F14 /* IssuanceRequest.swift */; };
 		559FCA5225CA042400737F14 /* LinkedDomainResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 559FCA5125CA042400737F14 /* LinkedDomainResult.swift */; };
 		559FCA5625CA0E6A00737F14 /* PresentationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 559FCA5525CA0E6A00737F14 /* PresentationRequest.swift */; };
+		55A2CA6D266EA44B00AE1A20 /* MeasureTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A2CA6C266EA44A00AE1A20 /* MeasureTime.swift */; };
 		55AC02B525D3087D00AA15F4 /* IdentifierDocumentServiceEndpointDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AC02B425D3087D00AA15F4 /* IdentifierDocumentServiceEndpointDescriptor.swift */; };
 		55AF747B252F5B4B006A8B25 /* IdentifierFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AF747A252F5B4A006A8B25 /* IdentifierFormatterTests.swift */; };
 		55AF747D252F64F7006A8B25 /* MockCryptoOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AF747C252F64F7006A8B25 /* MockCryptoOperations.swift */; };
@@ -232,6 +233,7 @@
 		559FCA3B25CA03D200737F14 /* IssuanceRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuanceRequest.swift; sourceTree = "<group>"; };
 		559FCA5125CA042400737F14 /* LinkedDomainResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedDomainResult.swift; sourceTree = "<group>"; };
 		559FCA5525CA0E6A00737F14 /* PresentationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationRequest.swift; sourceTree = "<group>"; };
+		55A2CA6C266EA44A00AE1A20 /* MeasureTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureTime.swift; sourceTree = "<group>"; };
 		55AC02B425D3087D00AA15F4 /* IdentifierDocumentServiceEndpointDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierDocumentServiceEndpointDescriptor.swift; sourceTree = "<group>"; };
 		55AF747A252F5B4A006A8B25 /* IdentifierFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierFormatterTests.swift; sourceTree = "<group>"; };
 		55AF747C252F64F7006A8B25 /* MockCryptoOperations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCryptoOperations.swift; sourceTree = "<group>"; };
@@ -271,6 +273,7 @@
 			isa = PBXGroup;
 			children = (
 				55011E8D2572DFBD002D2690 /* DefaultLogConsumer.swift */,
+				55A2CA6C266EA44A00AE1A20 /* MeasureTime.swift */,
 				5570597825754CA7000DD244 /* VCLogConsumer.swift */,
 				55011E8B2572DF50002D2690 /* VCSDKLog.swift */,
 				5570597A25754D02000DD244 /* VCTraceLevel.swift */,
@@ -819,6 +822,7 @@
 				55AF748E252F6BE0006A8B25 /* Identifier.swift in Sources */,
 				55AF7486252F6B1F006A8B25 /* IdentifierDocumentServiceEndpoint.swift in Sources */,
 				55BEF45D2589544500C720BD /* PinClaims.swift in Sources */,
+				55A2CA6D266EA44B00AE1A20 /* MeasureTime.swift in Sources */,
 				557BFC56251E6701005B5B24 /* IssuanceResponseContainer.swift in Sources */,
 				55575776251BC6CF009979AB /* RegistrationClaims.swift in Sources */,
 				55575777251BC6CF009979AB /* IssuanceServiceResponse.swift in Sources */,

--- a/VCEntities/VCEntities/logging/DefaultLogConsumer.swift
+++ b/VCEntities/VCEntities/logging/DefaultLogConsumer.swift
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 public struct DefaultVCLogConsumer: VCLogConsumer {
-
+    
     public init() {}
     
     public func log(_ traceLevel: VCTraceLevel,
@@ -13,5 +13,9 @@ public struct DefaultVCLogConsumer: VCLogConsumer {
                     file: String = #file,
                     line: Int = #line) {
         print("\(traceLevel): \(message) \nAt: \(functionName), \(file), \(line)")
+    }
+    
+    public func event(name: String, properties: [String : String]?, measurements: [String: NSNumber]? = nil) {
+        print("\(name): with properties: \(String(describing: properties))")
     }
 }

--- a/VCEntities/VCEntities/logging/MeasureTime.swift
+++ b/VCEntities/VCEntities/logging/MeasureTime.swift
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import PromiseKit
+
+struct MetricConstants {
+    static let Name = "eventName"
+    static let Duration = "duration_ms"
+}
+
+public func logNetworkTime(name: String,
+                    correlationVector: CorrelationHeader? = nil,
+                    _ block: @escaping () -> Promise<(data: Data, response: URLResponse)>) -> Promise<(data: Data, response: URLResponse)> {
+    let startTime = Date().timeIntervalSince1970
+    let result = block().get { body in
+        
+        let elapsedTime = Date().timeIntervalSince1970 - startTime
+        
+        var properties = [
+            MetricConstants.Name: name,
+            "CV_request": correlationVector?.value ?? ""
+        ]
+        
+        if let httpResponse = body.response as? HTTPURLResponse {
+            properties["isSuccessful"] = String(describing: httpResponse.statusCode >= 200 && httpResponse.statusCode < 300)
+            properties["CV_response"] = httpResponse.allHeaderFields[correlationVector?.name] as? String ?? ""
+            properties["code"] = String(describing: httpResponse.statusCode)
+        }
+        
+        let measurements = [MetricConstants.Duration: NSNumber(value: elapsedTime)]
+        
+        VCSDKLog.sharedInstance.event(name: name, properties: properties, measurements: measurements)
+    }
+
+    return result
+}

--- a/VCEntities/VCEntities/logging/MeasureTime.swift
+++ b/VCEntities/VCEntities/logging/MeasureTime.swift
@@ -31,7 +31,7 @@ public func logNetworkTime(name: String,
         
         let measurements = [MetricConstants.Duration: NSNumber(value: elapsedTime)]
         
-        VCSDKLog.sharedInstance.event(name: name, properties: properties, measurements: measurements)
+        VCSDKLog.sharedInstance.event(name: "DIDNetworkMetrics", properties: properties, measurements: measurements)
     }
 
     return result

--- a/VCEntities/VCEntities/logging/VCLogConsumer.swift
+++ b/VCEntities/VCEntities/logging/VCLogConsumer.swift
@@ -15,4 +15,13 @@ public protocol VCLogConsumer
              functionName: String,
              file: String,
              line: Int)
+    
+    /**
+     Creates an event with with event name and properties.
+     - Parameters:
+     - name: Name of the class calling the function.
+     - properties: dictionary of properties for the specific event.
+     - measurements: dictionary of measurements taken.
+     */
+    func event(name: String, properties: [String: String]?, measurements: [String: NSNumber]?)
 }

--- a/VCEntities/VCEntities/logging/VCSDKLog.swift
+++ b/VCEntities/VCEntities/logging/VCSDKLog.swift
@@ -93,4 +93,10 @@ public struct VCSDKLog {
         }
     }
     
+    func event(name: String, properties: [String: String]? = nil, measurements: [String: NSNumber]? = nil) {
+        consumers.forEach { logger in
+            logger.event(name: name, properties: properties, measurements: measurements)
+        }
+    }
+    
 }

--- a/VCNetworking/VCNetworking/operations/NetworkOperation.swift
+++ b/VCNetworking/VCNetworking/operations/NetworkOperation.swift
@@ -64,7 +64,9 @@ extension InternalNetworkOperation {
     
     private func call(urlSession: URLSession, urlRequest: URLRequest) -> Promise<ResponseBody> {
         return firstly {
-            urlSession.dataTask(.promise, with: urlRequest)
+            logNetworkTime(name: String(describing: Self.self), correlationVector: correlationVector) { [self] in
+                self.urlSession.dataTask(.promise, with: urlRequest)
+            }
         }.then { data, response in
             self.handleResponse(data: data, response: response)
         }


### PR DESCRIPTION
**Problem:**
We need to add metrics for measuring network calls and add to telemetry.


**Solution:**
We used the Android sdk implementation as a reference to add a `logNetworkTime` method that will measure how long each network call takes.


**Validation:**
The correct class is called for the eventName and all of these events are called "DIDNetworkMetrics".


**Type of change:**
- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [X] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.
