### PR TITLE
Add logTime

### DIFF
--- a/VCEntities/VCEntities/logging/MeasureTime.swift
+++ b/VCEntities/VCEntities/logging/MeasureTime.swift
@@ -13,14 +13,14 @@ struct MetricConstants {
 public func logTime<R>(name: String,
                     _ block: @escaping () -> Promise<R>) -> Promise<R> {
     
-    let startTime = Date().timeIntervalSince1970
+    let startTimeInSeconds = CFAbsoluteTimeGetCurrent()
     let result = block().get { body in
         
-        let elapsedTime = Date().timeIntervalSince1970 - startTime
+        let elapsedTimeInMilliseconds = (CFAbsoluteTimeGetCurrent() - startTimeInSeconds) * 1000
         
         VCSDKLog.sharedInstance.event(name: "DIDPerformanceMetrics",
                                       properties: [MetricConstants.Name: name],
-                                      measurements: [MetricConstants.Duration: NSNumber(value: elapsedTime)])
+                                      measurements: [MetricConstants.Duration: NSNumber(value: elapsedTimeInMilliseconds)])
     }
     
     return result
@@ -29,10 +29,11 @@ public func logTime<R>(name: String,
 public func logNetworkTime(name: String,
                     correlationVector: CorrelationHeader? = nil,
                     _ block: @escaping () -> Promise<(data: Data, response: URLResponse)>) -> Promise<(data: Data, response: URLResponse)> {
-    let startTime = Date().timeIntervalSince1970
+    
+    let startTimeInSeconds = CFAbsoluteTimeGetCurrent()
     let result = block().get { body in
         
-        let elapsedTime = Date().timeIntervalSince1970 - startTime
+        let elapsedTimeInMilliseconds = (CFAbsoluteTimeGetCurrent() - startTimeInSeconds) * 1000
         
         var properties = [
             MetricConstants.Name: name,
@@ -45,7 +46,7 @@ public func logNetworkTime(name: String,
             properties["code"] = String(describing: httpResponse.statusCode)
         }
         
-        let measurements = [MetricConstants.Duration: NSNumber(value: elapsedTime)]
+        let measurements = [MetricConstants.Duration: NSNumber(value: elapsedTimeInMilliseconds)]
         
         VCSDKLog.sharedInstance.event(name: "DIDNetworkMetrics", properties: properties, measurements: measurements)
     }

--- a/VCEntities/VCEntities/logging/MeasureTime.swift
+++ b/VCEntities/VCEntities/logging/MeasureTime.swift
@@ -10,6 +10,22 @@ struct MetricConstants {
     static let Duration = "duration_ms"
 }
 
+public func logTime<R>(name: String,
+                    _ block: @escaping () -> Promise<R>) -> Promise<R> {
+    
+    let startTime = Date().timeIntervalSince1970
+    let result = block().get { body in
+        
+        let elapsedTime = Date().timeIntervalSince1970 - startTime
+        
+        VCSDKLog.sharedInstance.event(name: "DIDPerformanceMetrics",
+                                      properties: [MetricConstants.Name: name],
+                                      measurements: [MetricConstants.Duration: NSNumber(value: elapsedTime)])
+    }
+    
+    return result
+}
+
 public func logNetworkTime(name: String,
                     correlationVector: CorrelationHeader? = nil,
                     _ block: @escaping () -> Promise<(data: Data, response: URLResponse)>) -> Promise<(data: Data, response: URLResponse)> {

--- a/VCServices/VCServices/IssuanceService.swift
+++ b/VCServices/VCServices/IssuanceService.swift
@@ -49,13 +49,13 @@ public class IssuanceService {
         self.sdkLog = sdkLog
     }
     
-    
-    /// TODO: add DNS Binding for contracts
     public func getRequest(usingUrl url: String) -> Promise<IssuanceRequest> {
-        return firstly {
-            self.apiCalls.getRequest(withUrl: url)
-        }.then { signedContract in
-            self.formIssuanceRequest(from: signedContract)
+        return logTime(name: "Issuance getRequest") {
+            firstly {
+                self.apiCalls.getRequest(withUrl: url)
+            }.then { signedContract in
+                self.formIssuanceRequest(from: signedContract)
+            }
         }
     }
     
@@ -71,12 +71,14 @@ public class IssuanceService {
     }
     
     public func send(response: IssuanceResponseContainer, isPairwise: Bool = false) -> Promise<VerifiableCredential> {
-        return firstly {
-            self.exchangeVCsIfPairwise(response: response, isPairwise: isPairwise)
-        }.then { response in
-            self.formatIssuanceResponse(response: response, isPairwise: isPairwise)
-        }.then { signedToken in
-            self.apiCalls.sendResponse(usingUrl:  response.audienceUrl, withBody: signedToken)
+        return logTime(name: "Issuance sendResponse") {
+            firstly {
+                self.exchangeVCsIfPairwise(response: response, isPairwise: isPairwise)
+            }.then { response in
+                self.formatIssuanceResponse(response: response, isPairwise: isPairwise)
+            }.then { signedToken in
+                self.apiCalls.sendResponse(usingUrl:  response.audienceUrl, withBody: signedToken)
+            }
         }
     }
     

--- a/VCServices/VCServices/PresentationService.swift
+++ b/VCServices/VCServices/PresentationService.swift
@@ -63,22 +63,26 @@ public class PresentationService {
     }
     
     public func getRequest(usingUrl urlStr: String) -> Promise<PresentationRequest> {
-        return firstly {
-            self.getRequestUriPromise(from: urlStr)
-        }.then { requestUri in
-            self.fetchValidatedRequest(usingUrl: requestUri)
-        }.then { presentationRequestToken in
-            self.formPresentationRequest(from: presentationRequestToken)
+        return logTime(name: "Presentation getRequest") {
+            firstly {
+                self.getRequestUriPromise(from: urlStr)
+            }.then { requestUri in
+                self.fetchValidatedRequest(usingUrl: requestUri)
+            }.then { presentationRequestToken in
+                self.formPresentationRequest(from: presentationRequestToken)
+            }
         }
     }
     
     public func send(response: PresentationResponseContainer, isPairwise: Bool = false) -> Promise<String?> {
-        return firstly {
-            self.exchangeVCsIfPairwise(response: response, isPairwise: isPairwise)
-        }.then { response in
-            self.formatPresentationResponse(response: response, isPairwise: isPairwise)
-        }.then { signedToken in
-            self.presentationApiCalls.sendResponse(usingUrl:  response.audienceUrl, withBody: signedToken)
+        return logTime(name: "Presentation sendResponse") {
+            firstly {
+                self.exchangeVCsIfPairwise(response: response, isPairwise: isPairwise)
+            }.then { response in
+                self.formatPresentationResponse(response: response, isPairwise: isPairwise)
+            }.then { signedToken in
+                self.presentationApiCalls.sendResponse(usingUrl:  response.audienceUrl, withBody: signedToken)
+            }
         }
     }
     


### PR DESCRIPTION
**Problem:**
We need to add telemetry to log how long it takes to get presentation/issuance requests and send presentation/issuance responses to have the same telemetry as Android.


**Solution:**
Add `logTime` method to match Android's implementation.


**Validation:**
Works as intended when getting/presenting cards.


**Type of change:**
- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [X] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.
