### PR TITLE
Keep jwk as ECPublicJwk

### DIFF
--- a/VCToken/VCToken/Header.swift
+++ b/VCToken/VCToken/Header.swift
@@ -6,12 +6,12 @@
 public struct Header: Codable {
     public let type: String?
     public let algorithm: String?
-    public let jsonWebKey: String?
+    public let jsonWebKey: ECPublicJwk?
     public let keyId: String?
     
     public init(type: String? = nil,
                 algorithm: String? = nil,
-                jsonWebKey: String? = nil,
+                jsonWebKey: ECPublicJwk? = nil,
                 keyId: String? = nil) {
         self.type = type
         self.algorithm = algorithm
@@ -32,7 +32,7 @@ public struct Header: Codable {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         type = try values.decodeIfPresent(String.self, forKey: .type)
         algorithm = try values.decodeIfPresent(String.self, forKey: .algorithm)
-        jsonWebKey = try values.decodeIfPresent(String.self, forKey: .jsonWebKey)
+        jsonWebKey = try values.decodeIfPresent(ECPublicJwk.self, forKey: .jsonWebKey)
         keyId = try values.decodeIfPresent(String.self, forKey: .keyId)
     }
 


### PR DESCRIPTION
The jwk property inside the Header json should not be stringified.

**Problem:**
The jwk property inside the Header json is stringified after the jwt serialization.


**Solution:**
Keep jwk as `ECPublicJwk`, so it will be serialized as json.


**Validation:**
Please include here how it was verified that the PR works as intended.


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
https://datatracker.ietf.org/doc/html/rfc7517#section-2
