### PR TITLE
Fix bug found when dealing with percentEncoding strings

### DIFF
--- a/VCNetworking/VCNetworking/extensions/String+PercentEncoding.swift
+++ b/VCNetworking/VCNetworking/extensions/String+PercentEncoding.swift
@@ -7,7 +7,7 @@ import Foundation
 
 extension String {
   func stringByAddingPercentEncodingForRFC3986() -> String? {
-    let unreserved = ":-._~/?%"
+    let unreserved = ":-._~/?%="
     let allowed = NSMutableCharacterSet.alphanumeric()
     allowed.addCharacters(in: unreserved)
     return addingPercentEncoding(withAllowedCharacters: allowed as CharacterSet)


### PR DESCRIPTION
**Problem:**
"=" was getting percent encoded, and they should not be.


**Solution:**
Added "=" to allowed character list.


**Validation:**
Demo site now works as expected.


**Type of change:**
- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.
