### PR TITLE
Expose IdentifierService to make user DID available for idToken binding

### DIFF
--- a/VCEntities/VCEntities/identifier/Identifier.swift
+++ b/VCEntities/VCEntities/identifier/Identifier.swift
@@ -11,7 +11,14 @@ public struct Identifier {
     public let updateKey: KeyContainer
     public let recoveryKey: KeyContainer
     public let alias: String
-    
+
+    public var did: String
+    {
+        get {
+            return longFormDid
+        }
+    }
+
     public init(longFormDid: String,
                 didDocumentKeys: [KeyContainer],
                 updateKey: KeyContainer,

--- a/VCServices/VCServices/IdentifierService.swift
+++ b/VCServices/VCServices/IdentifierService.swift
@@ -5,14 +5,14 @@
 
 import VCEntities
 
-class IdentifierService {
+public class IdentifierService {
     
     private let identifierDB: IdentifierDatabase
     private let identifierCreator: IdentifierCreator
     private let sdkLog: VCSDKLog
     private let aliasComputer = AliasComputer()
     
-    convenience init() {
+    public convenience init() {
         self.init(database: IdentifierDatabase(),
                   creator: IdentifierCreator(),
                   sdkLog: VCSDKLog.sharedInstance)
@@ -26,7 +26,7 @@ class IdentifierService {
         self.sdkLog = sdkLog
     }
     
-    func fetchMasterIdentifier() throws -> Identifier {
+    public func fetchMasterIdentifier() throws -> Identifier {
         return try identifierDB.fetchMasterIdentifier()
     }
     


### PR DESCRIPTION
**Problem:**
The IdentifierService was not accessible outside of the SDK, but the user DID was needed for binding to idToken(s)


**Solution:**
Make the IdentifierService public.


**Type of change:**
- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1803236

