### PR TITLE
Access Token Attestation in Contracts

### DIFF
--- a/VCEntities/VCEntities.xcodeproj/project.pbxproj
+++ b/VCEntities/VCEntities.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		551F3063252E6E230081D5E7 /* Multihash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551F3062252E6E230081D5E7 /* Multihash.swift */; };
 		551F3066252E71680081D5E7 /* MultihashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551F3065252E71680081D5E7 /* MultihashTests.swift */; };
 		551F3068252E97000081D5E7 /* IdentifierCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551F3067252E97000081D5E7 /* IdentifierCreator.swift */; };
+		5522D04F27DA727400617D15 /* AccessTokenDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5522D04E27DA727400617D15 /* AccessTokenDescriptor.swift */; };
 		55253976252FCA6D003202D5 /* VCCrypto.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55253975252FCA6D003202D5 /* VCCrypto.framework */; };
 		55253982252FDF89003202D5 /* KeyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55253981252FDF89003202D5 /* KeyContainer.swift */; };
 		5531D3AC255F03EF0002CC0E /* AliasComputer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5531D3AB255F03EF0002CC0E /* AliasComputer.swift */; };
@@ -164,6 +165,7 @@
 		551F3062252E6E230081D5E7 /* Multihash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Multihash.swift; sourceTree = "<group>"; };
 		551F3065252E71680081D5E7 /* MultihashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultihashTests.swift; sourceTree = "<group>"; };
 		551F3067252E97000081D5E7 /* IdentifierCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierCreator.swift; sourceTree = "<group>"; };
+		5522D04E27DA727400617D15 /* AccessTokenDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenDescriptor.swift; sourceTree = "<group>"; };
 		55253975252FCA6D003202D5 /* VCCrypto.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = VCCrypto.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		55253981252FDF89003202D5 /* KeyContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyContainer.swift; sourceTree = "<group>"; };
 		5531D3AB255F03EF0002CC0E /* AliasComputer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasComputer.swift; sourceTree = "<group>"; };
@@ -422,7 +424,6 @@
 				5577E864251E82B2005250BC /* verifiableCredential */,
 				555CE08B252680B600C1C938 /* verifiablePresentation */,
 				55AF7481252F6803006A8B25 /* util */,
-				5557575A251BC6CF009979AB /* AttestationResponseDescriptor.swift */,
 				5531D3B1255F6B6E0002CC0E /* ResponseContaining.swift */,
 				5518CC7525264D5700C7A21B /* ResponseMappings.swift */,
 				55575731251BC575009979AB /* VCEntities.h */,
@@ -452,6 +453,7 @@
 			isa = PBXGroup;
 			children = (
 				5557574B251BC6CE009979AB /* AttestationsDescriptor.swift */,
+				5522D04E27DA727400617D15 /* AccessTokenDescriptor.swift */,
 				5557574C251BC6CE009979AB /* PresentationDescriptor.swift */,
 				5557574D251BC6CE009979AB /* ConsentDisplayDescriptor.swift */,
 				5557574E251BC6CE009979AB /* LogoDisplayDescriptor.swift */,
@@ -502,6 +504,7 @@
 				559FCA3B25CA03D200737F14 /* IssuanceRequest.swift */,
 				557BFC55251E6701005B5B24 /* IssuanceResponseContainer.swift */,
 				55575761251BC6CF009979AB /* IssuanceServiceResponse.swift */,
+				5557575A251BC6CF009979AB /* AttestationResponseDescriptor.swift */,
 				559FC9B725C9C7DD00737F14 /* ContractServiceResponse.swift */,
 				55FE6ED72697A06D00201EDC /* IssuanceCompletionResponse.swift */,
 				5599D0CB26A07EE10037C131 /* IssuancePin.swift */,
@@ -868,6 +871,7 @@
 				55B4D2D62787BBED0086A9F1 /* AllowedAlgorithms.swift in Sources */,
 				5584E49925255ACA00A9DE58 /* PresentationRequestClaims.swift in Sources */,
 				55575771251BC6CF009979AB /* AttestationResponseDescriptor.swift in Sources */,
+				5522D04F27DA727400617D15 /* AccessTokenDescriptor.swift in Sources */,
 				55575763251BC6CF009979AB /* AttestationsDescriptor.swift in Sources */,
 				559FCA5225CA042400737F14 /* LinkedDomainResult.swift in Sources */,
 				55077ACA25A7763B0052C58D /* IdentifierDocumentPublicKey.swift in Sources */,

--- a/VCEntities/VCEntities/ResponseMappings.swift
+++ b/VCEntities/VCEntities/ResponseMappings.swift
@@ -4,5 +4,6 @@
 *--------------------------------------------------------------------------------------------*/
 
 public typealias RequestedIdTokenMap = [String:String]
+public typealias RequestedAccessTokenMap = [String: String]
 public typealias RequestedSelfAttestedClaimMap = [String: String]
 public typealias RequestedVerifiableCredentialMap = [RequestedVerifiableCredentialMapping]

--- a/VCEntities/VCEntities/formatters/IssuanceResponseFormatter.swift
+++ b/VCEntities/VCEntities/formatters/IssuanceResponseFormatter.swift
@@ -67,6 +67,11 @@ public class IssuanceResponseFormatter: IssuanceResponseFormatting {
     
     private func formatAttestations(response: IssuanceResponseContainer, usingIdentifier identifier: Identifier, andSignWith key: KeyContainer) throws -> AttestationResponseDescriptor? {
         
+        var accessTokenMap: RequestedAccessTokenMap? = nil
+        if !response.requestedAccessTokenMap.isEmpty {
+            accessTokenMap = response.requestedAccessTokenMap
+        }
+        
         var idTokenMap: RequestedIdTokenMap? = nil
         if !response.requestedIdTokenMap.isEmpty {
             idTokenMap = response.requestedIdTokenMap
@@ -93,7 +98,10 @@ public class IssuanceResponseFormatter: IssuanceResponseFormatting {
             verifiable credentials: \(presentationsMap?.count ?? 0)
             """)
         
-        return AttestationResponseDescriptor(idTokens: idTokenMap, presentations: presentationsMap, selfIssued: selfIssuedMap)
+        return AttestationResponseDescriptor(accessTokens: accessTokenMap,
+                                             idTokens: idTokenMap,
+                                             presentations: presentationsMap,
+                                             selfIssued: selfIssuedMap)
     }
     
     private func createPresentations(from response: IssuanceResponseContainer, usingIdentifier identifier: Identifier, andSignWith key: KeyContainer) throws -> [String: String]? {

--- a/VCEntities/VCEntities/formatters/IssuanceResponseFormatter.swift
+++ b/VCEntities/VCEntities/formatters/IssuanceResponseFormatter.swift
@@ -51,7 +51,11 @@ public class IssuanceResponseFormatter: IssuanceResponseFormatting {
         let timeConstraints = TokenTimeConstraints(expiryInSeconds: response.expiryInSeconds)
         let attestations = try self.formatAttestations(response: response, usingIdentifier: identifier, andSignWith: key)
         
-        let pin = try response.issuancePin?.hash()
+        var pin: String? = nil
+        if response.issuanceIdToken != nil
+        {
+            pin = try response.issuancePin?.hash()
+        }
         
         return IssuanceResponseClaims(publicKeyThumbprint: try publicKey.getThumbprint(),
                                       audience: response.audienceUrl,

--- a/VCEntities/VCEntities/issuance/AttestationResponseDescriptor.swift
+++ b/VCEntities/VCEntities/issuance/AttestationResponseDescriptor.swift
@@ -6,13 +6,16 @@
 import VCToken
 
 public struct AttestationResponseDescriptor: Codable {
-    public let idTokens: [String: String]?
+    public let accessTokens: RequestedAccessTokenMap?
+    public let idTokens: RequestedIdTokenMap?
     public let presentations: [String: String]?
-    public let selfIssued: [String: String]?
+    public let selfIssued: RequestedSelfAttestedClaimMap?
     
-    public init(idTokens: [String: String]? = nil,
+    public init(accessTokens: RequestedAccessTokenMap? = nil,
+                idTokens: RequestedIdTokenMap? = nil,
                 presentations: [String: String]? = nil,
-                selfIssued: [String: String]? = nil) {
+                selfIssued: RequestedSelfAttestedClaimMap? = nil) {
+        self.accessTokens = accessTokens
         self.idTokens = idTokens
         self.presentations = presentations
         self.selfIssued = selfIssued

--- a/VCEntities/VCEntities/issuance/IssuanceResponseContainer.swift
+++ b/VCEntities/VCEntities/issuance/IssuanceResponseContainer.swift
@@ -14,6 +14,7 @@ public struct IssuanceResponseContainer: ResponseContaining {
     public var issuancePin: IssuancePin? = nil
     public var issuanceIdToken: String? = nil
     public var requestedIdTokenMap: RequestedIdTokenMap = [:]
+    public var requestedAccessTokenMap: RequestedAccessTokenMap = [:]
     public var requestedSelfAttestedClaimMap: RequestedSelfAttestedClaimMap = [:]
     public var requestVCMap: RequestedVerifiableCredentialMap = []
     

--- a/VCEntities/VCEntities/issuance/contract/AccessTokenDescriptor.swift
+++ b/VCEntities/VCEntities/issuance/contract/AccessTokenDescriptor.swift
@@ -3,9 +3,13 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-public struct AttestationsDescriptor: Codable, Equatable {
-    public let selfIssued: SelfIssuedClaimsDescriptor?
-    public let presentations: [PresentationDescriptor]?
-    public let idTokens: [IdTokenDescriptor]?
-    public let accessTokens: [AccessTokenDescriptor]?
+public struct AccessTokenDescriptor: Codable, Equatable {
+    
+    public let id: String?
+    public let encrypted: Bool?
+    public let claims: [ClaimDescriptor]?
+    public let required: Bool?
+    public let configuration: String?
+    public let resourceId: String?
+    public let oboScope: String?
 }


### PR DESCRIPTION
**Problem:**
- We needed to add an access token attestation to issuance request.


**Solution:**
- Added the attestation to Contract entity and added it to issuance request formatter.
- Fixed a bug as well where we cannot send a pin to issuance service unless there is an IdTokenHint.


**Validation:**
- All test pass
- Flow works E2E


**Type of change:**
- [X] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.
