### PR TITLE
Add access group to key storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,18 @@ To learn more about verifiable credentials, please review our [documentation.](h
 ## Initializing SDK
 `VerifiableCredentialSDK` - this class is used to initialize the SDK. You may want to call during your dependency injection initialization:
 ```swift
-VerifiableCredentialSDK.initialize();
+/// Both parameters are optional:
+/// - logConsumer: conforms to the VCLogConsumer to inject logging into the SDK.
+/// - accessGroupIdentifier: String to tell the SDK where to save keys in KeyChain. If nil, will use the default access group.
+/// Returns: Result<VCSDKStatus, Error>
+let result = VerifiableCredentialSDK.initialize(logConsumer: sdkLogConsumer, accessGroupIdentifier: accessGroupIdentifier);
+
+switch result {
+    case .success(let status):
+        print("\(status) will equal success or new master identifier created")
+    case .failure(let error):
+        print("Initialization failed because of specific error")
+}
 ```
 
 We currently support the following services:

--- a/VCCrypto/VCCrypto/CryptoOperations.swift
+++ b/VCCrypto/VCCrypto/CryptoOperations.swift
@@ -12,22 +12,25 @@ public struct CryptoOperations: CryptoOperating {
 
     private let secretStore: SecretStoring
     
-    public init() {
-        self.init(secretStore: KeychainSecretStore())
+    private let accessGroup: String?
+    
+    public init(accessGroup: String?) {
+        self.init(secretStore: KeychainSecretStore(), accessGroup: accessGroup)
     }
     
-    public init(secretStore: SecretStoring) {
+    public init(secretStore: SecretStoring, accessGroup: String?) {
         self.secretStore = secretStore
+        self.accessGroup = accessGroup
     }
     
     public func generateKey() throws -> VCCryptoSecret {
         
-        let key = try Random32BytesSecret(withStore: secretStore)
+        let key = try Random32BytesSecret(withStore: secretStore, inAccessGroup: accessGroup)
         
         return key
     }
     
     public func retrieveKeyFromStorage(withId id: UUID) throws -> VCCryptoSecret {
-        return Random32BytesSecret(withStore: secretStore, andId: id)
+        return try Random32BytesSecret(withStore: secretStore, andId: id, inAccessGroup: accessGroup)
     }
 }

--- a/VCCrypto/VCCrypto/CryptoOperations.swift
+++ b/VCCrypto/VCCrypto/CryptoOperations.swift
@@ -5,7 +5,7 @@
 
 public protocol CryptoOperating {
     func generateKey() throws -> VCCryptoSecret
-    func retrieveKeyFromStorage(withId id: UUID) throws -> VCCryptoSecret
+    func retrieveKeyFromStorage(withId id: UUID) -> VCCryptoSecret
 }
 
 public struct CryptoOperations: CryptoOperating {
@@ -30,7 +30,7 @@ public struct CryptoOperations: CryptoOperating {
         return key
     }
     
-    public func retrieveKeyFromStorage(withId id: UUID) throws -> VCCryptoSecret {
-        return try Random32BytesSecret(withStore: secretStore, andId: id, inAccessGroup: accessGroup)
+    public func retrieveKeyFromStorage(withId id: UUID) -> VCCryptoSecret {
+        return Random32BytesSecret(withStore: secretStore, andId: id, inAccessGroup: accessGroup)
     }
 }

--- a/VCCrypto/VCCrypto/KeychainSecretStore.swift
+++ b/VCCrypto/VCCrypto/KeychainSecretStore.swift
@@ -38,8 +38,7 @@ struct KeychainSecretStore : SecretStoring {
         }
         
         var item: CFTypeRef?
-        var status = SecItemCopyMatching(query as CFDictionary, &item)
-        print(status)
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
         guard status != errSecItemNotFound else { throw KeychainStoreError.itemNotFound }
         guard status == errSecSuccess else { throw KeychainStoreError.readFromStoreError(status: status as OSStatus) }
         guard var value = item as? Data else { throw KeychainStoreError.invalidItemInStore }

--- a/VCCrypto/VCCrypto/KeychainSecretStore.swift
+++ b/VCCrypto/VCCrypto/KeychainSecretStore.swift
@@ -89,7 +89,8 @@ struct KeychainSecretStore : SecretStoring {
         
         let status = SecItemAdd(query as CFDictionary, nil)
         guard status == errSecSuccess else {
-            throw KeychainStoreError.saveToStoreError(status: status)}
+            throw KeychainStoreError.saveToStoreError(status: status)
+        }
     }
     
     /// Delete the secret from keychain
@@ -98,15 +99,7 @@ struct KeychainSecretStore : SecretStoring {
     ///   - id: The Id of the secret
     ///   - itemTypeCode: The secret type code (4 chars)
     ///   - accessGroup: The access group of the secret.
-    ///   - value: The value of the secret
-    func deleteSecret(id: UUID, itemTypeCode: String, accessGroup: String? = nil, value: inout Data) throws {
-        defer {
-            let secretSize = value.count
-            value.withUnsafeMutableBytes { (secretPtr) in
-                memset_s(secretPtr.baseAddress, secretSize, 0, secretSize)
-                return
-            }
-        }
+    func deleteSecret(id: UUID, itemTypeCode: String, accessGroup: String? = nil) throws {
         
         guard itemTypeCode.count == 4 else { throw KeychainStoreError.invalidType }
         
@@ -117,8 +110,7 @@ struct KeychainSecretStore : SecretStoring {
                      kSecAttrAccount: id.uuidString,
                      kSecAttrService: vcService,
                      kSecAttrType: itemTypeCode,
-                     kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-                     kSecValueData: value] as [String: Any]
+                     kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly] as [String: Any]
         
         if let accessGroup = accessGroup,
                accessGroup != "" {
@@ -127,6 +119,7 @@ struct KeychainSecretStore : SecretStoring {
         
         let status = SecItemDelete(query as CFDictionary)
         guard status == errSecSuccess else {
-            throw KeychainStoreError.deleteFromStoreError(status: status)}
+            throw KeychainStoreError.deleteFromStoreError(status: status)
+        }
     }
 }

--- a/VCCrypto/VCCrypto/Keys/Random32BytesSecret.swift
+++ b/VCCrypto/VCCrypto/Keys/Random32BytesSecret.swift
@@ -71,17 +71,16 @@ final class Random32BytesSecret: Secret {
         }
     }
     
-    func migrateKey(fromAccessGroup oldAccessGroup: String?) throws {
+    func migrateKey(fromAccessGroup currentAccessGroup: String?) throws {
         
         /// If old access group is equal to new access group, no action required.
-        if oldAccessGroup == accessGroup
-        {
+        if currentAccessGroup == accessGroup {
             return
         }
         
         var value = try self.store.getSecret(id: id,
                                              itemTypeCode: Random32BytesSecret.itemTypeCode,
-                                             accessGroup: oldAccessGroup)
+                                             accessGroup: currentAccessGroup)
         defer {
             let secretSize = value.count
             value.withUnsafeMutableBytes { (secretPtr) in
@@ -99,8 +98,7 @@ final class Random32BytesSecret: Secret {
         /// Delete from old access group
         try self.store.deleteSecret(id: id,
                                     itemTypeCode: Random32BytesSecret.itemTypeCode,
-                                    accessGroup: oldAccessGroup,
-                                    value: &value)
+                                    accessGroup: currentAccessGroup)
         
         
     }

--- a/VCCrypto/VCCrypto/Keys/Random32BytesSecret.swift
+++ b/VCCrypto/VCCrypto/Keys/Random32BytesSecret.swift
@@ -16,7 +16,7 @@ final class Random32BytesSecret: Secret {
     private let store: SecretStoring
     private let accessGroup: String?
     
-    init(withStore store: SecretStoring, andId id: UUID, inAccessGroup accessGroup: String? = nil) throws {
+    init(withStore store: SecretStoring, andId id: UUID, inAccessGroup accessGroup: String? = nil) {
         self.id = id
         self.store = store
         self.accessGroup = accessGroup

--- a/VCCrypto/VCCrypto/Keys/Secret.swift
+++ b/VCCrypto/VCCrypto/Keys/Secret.swift
@@ -7,14 +7,14 @@ import Foundation
 
 internal protocol Secret: VCCryptoSecret & InternalSecret {}
 
-public protocol VCCryptoSecret{
+public protocol VCCryptoSecret {
     
     /// The secret id
     var id:UUID { get }
     
     func isValidKey() -> Bool
     
-    func updateAccessGroup() throws
+    func migrateKey(fromAccessGroup oldAccessGroup: String?) throws
 }
 
 protocol InternalSecret  {

--- a/VCCrypto/VCCrypto/Keys/Secret.swift
+++ b/VCCrypto/VCCrypto/Keys/Secret.swift
@@ -14,7 +14,7 @@ public protocol VCCryptoSecret {
     
     func isValidKey() -> Bool
     
-    func migrateKey(fromAccessGroup oldAccessGroup: String?) throws
+    func migrateKey(fromAccessGroup currentAccessGroup: String?) throws
 }
 
 protocol InternalSecret  {

--- a/VCCrypto/VCCrypto/Keys/Secret.swift
+++ b/VCCrypto/VCCrypto/Keys/Secret.swift
@@ -11,6 +11,10 @@ public protocol VCCryptoSecret{
     
     /// The secret id
     var id:UUID { get }
+    
+    func isValidKey() -> Bool
+    
+    func updateAccessGroup() throws
 }
 
 protocol InternalSecret  {

--- a/VCCrypto/VCCrypto/SecretStoring.swift
+++ b/VCCrypto/VCCrypto/SecretStoring.swift
@@ -8,6 +8,6 @@ import Foundation
 // public until Identifier Creation is implemented.
 public protocol SecretStoring {
     
-    func getSecret(id: UUID, itemTypeCode: String) throws -> Data
-    func saveSecret(id: UUID, itemTypeCode: String, value: inout Data) throws
+    func getSecret(id: UUID, itemTypeCode: String, accessGroup: String?) throws -> Data
+    func saveSecret(id: UUID, itemTypeCode: String, accessGroup: String?, value: inout Data) throws
 }

--- a/VCCrypto/VCCrypto/SecretStoring.swift
+++ b/VCCrypto/VCCrypto/SecretStoring.swift
@@ -10,5 +10,5 @@ public protocol SecretStoring {
     
     func getSecret(id: UUID, itemTypeCode: String, accessGroup: String?) throws -> Data
     func saveSecret(id: UUID, itemTypeCode: String, accessGroup: String?, value: inout Data) throws
-    func deleteSecret(id: UUID, itemTypeCode: String, accessGroup: String?, value: inout Data) throws
+    func deleteSecret(id: UUID, itemTypeCode: String, accessGroup: String?) throws
 }

--- a/VCCrypto/VCCrypto/SecretStoring.swift
+++ b/VCCrypto/VCCrypto/SecretStoring.swift
@@ -10,4 +10,5 @@ public protocol SecretStoring {
     
     func getSecret(id: UUID, itemTypeCode: String, accessGroup: String?) throws -> Data
     func saveSecret(id: UUID, itemTypeCode: String, accessGroup: String?, value: inout Data) throws
+    func deleteSecret(id: UUID, itemTypeCode: String, accessGroup: String?, value: inout Data) throws
 }

--- a/VCCrypto/VCCryptoTests/Mocks/SecretMock.swift
+++ b/VCCrypto/VCCryptoTests/Mocks/SecretMock.swift
@@ -8,6 +8,7 @@ import Foundation
 @testable import VCCrypto
 
 final class SecretMock : Secret {
+    
     static var itemTypeCode: String = "MOCK"
     var id: UUID
     private var value: Data
@@ -22,4 +23,10 @@ final class SecretMock : Secret {
             try body(valuePtr)
         }
     }
+    
+    func isValidKey() -> Bool {
+        return true
+    }
+    
+    func migrateKey(fromAccessGroup oldAccessGroup: String?) throws { }
 }

--- a/VCCrypto/VCCryptoTests/Mocks/SecretStoreMock.swift
+++ b/VCCrypto/VCCryptoTests/Mocks/SecretStoreMock.swift
@@ -10,11 +10,15 @@ internal class SecretStoreMock: SecretStoring {
     
     private var memoryStore = [UUID: Data]()
     
-    func getSecret(id: UUID, itemTypeCode: String) throws -> Data {
+    func getSecret(id: UUID, itemTypeCode: String, accessGroup: String?) throws -> Data {
         return memoryStore[id]!
     }
     
-    func saveSecret(id: UUID, itemTypeCode: String, value: inout Data) throws {
+    func saveSecret(id: UUID, itemTypeCode: String, accessGroup: String?, value: inout Data) throws {
         memoryStore[id] = value
+    }
+    
+    func deleteSecret(id: UUID, itemTypeCode: String, accessGroup: String?, value: inout Data) throws {
+        memoryStore.removeValue(forKey: id)
     }
 }

--- a/VCCrypto/VCCryptoTests/Mocks/SecretStoreMock.swift
+++ b/VCCrypto/VCCryptoTests/Mocks/SecretStoreMock.swift
@@ -18,7 +18,7 @@ internal class SecretStoreMock: SecretStoring {
         memoryStore[id] = value
     }
     
-    func deleteSecret(id: UUID, itemTypeCode: String, accessGroup: String?, value: inout Data) throws {
+    func deleteSecret(id: UUID, itemTypeCode: String, accessGroup: String?) throws {
         memoryStore.removeValue(forKey: id)
     }
 }

--- a/VCCrypto/VCCryptoTests/Random32BytesSecretTests.swift
+++ b/VCCrypto/VCCryptoTests/Random32BytesSecretTests.swift
@@ -12,7 +12,7 @@ class Random32BytesSecretTests: XCTestCase {
         let store = SecretStoreMock()
         let secret = try Random32BytesSecret(withStore: store)
         
-        let value = try store.getSecret(id: secret.id, itemTypeCode: Random32BytesSecret.itemTypeCode)
+        let value = try store.getSecret(id: secret.id, itemTypeCode: Random32BytesSecret.itemTypeCode, accessGroup: nil)
         XCTAssertTrue(value.count == 32)
     }
 
@@ -32,7 +32,7 @@ class Random32BytesSecretTests: XCTestCase {
         let secret = try Random32BytesSecret(withStore: store)
         try secret.withUnsafeBytes { (valuePtr) in
             let val = Data(valuePtr)
-            XCTAssertEqual(val, try store.getSecret(id: secret.id, itemTypeCode: Random32BytesSecret.itemTypeCode))
+            XCTAssertEqual(val, try store.getSecret(id: secret.id, itemTypeCode: Random32BytesSecret.itemTypeCode, accessGroup: nil))
         }
     }
 }

--- a/VCEntities/VCEntities.xcodeproj/project.pbxproj
+++ b/VCEntities/VCEntities.xcodeproj/project.pbxproj
@@ -71,7 +71,6 @@
 		5573FEFA25B8DE5900282BC7 /* IONDocumentInitialState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5573FEF925B8DE5900282BC7 /* IONDocumentInitialState.swift */; };
 		5573FF0025B8DE6900282BC7 /* IdentifierDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5573FEFE25B8DE6900282BC7 /* IdentifierDocument.swift */; };
 		5573FF0125B8DE6900282BC7 /* DiscoveryServiceResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5573FEFF25B8DE6900282BC7 /* DiscoveryServiceResponse.swift */; };
-		5574956325E85987005A924B /* VCSDKConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5574956225E85987005A924B /* VCSDKConfiguration.swift */; };
 		5577E867251E8368005250BC /* MockCodableObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5577E866251E8368005250BC /* MockCodableObject.swift */; };
 		5577E869251E8395005250BC /* JSONCodingKeysTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5577E868251E8395005250BC /* JSONCodingKeysTests.swift */; };
 		5577E86C251E86C2005250BC /* VerifiableCredentialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5577E86B251E86C2005250BC /* VerifiableCredentialTests.swift */; };
@@ -131,6 +130,7 @@
 		55BEF4252587D28000C720BD /* IssuerIdTokenClaims.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BEF4242587D28000C720BD /* IssuerIdTokenClaims.swift */; };
 		55BEF45D2589544500C720BD /* PinClaims.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BEF45C2589544500C720BD /* PinClaims.swift */; };
 		55BEF461258A5E0400C720BD /* IssuerIdToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BEF460258A5E0400C720BD /* IssuerIdToken.swift */; };
+		55CA3A8127FB635300615CB6 /* VCSDKConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CA3A8027FB635300615CB6 /* VCSDKConfiguration.swift */; };
 		55CE4C6025EEE99B00595CC7 /* CorrelationHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CE4C5F25EEE99B00595CC7 /* CorrelationHeader.swift */; };
 		55FE6ED82697A06D00201EDC /* IssuanceCompletionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FE6ED72697A06D00201EDC /* IssuanceCompletionResponse.swift */; };
 /* End PBXBuildFile section */
@@ -213,7 +213,6 @@
 		5573FEF925B8DE5900282BC7 /* IONDocumentInitialState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IONDocumentInitialState.swift; sourceTree = "<group>"; };
 		5573FEFE25B8DE6900282BC7 /* IdentifierDocument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifierDocument.swift; sourceTree = "<group>"; };
 		5573FEFF25B8DE6900282BC7 /* DiscoveryServiceResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscoveryServiceResponse.swift; sourceTree = "<group>"; };
-		5574956225E85987005A924B /* VCSDKConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VCSDKConfiguration.swift; sourceTree = "<group>"; };
 		5577E866251E8368005250BC /* MockCodableObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCodableObject.swift; sourceTree = "<group>"; };
 		5577E868251E8395005250BC /* JSONCodingKeysTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONCodingKeysTests.swift; sourceTree = "<group>"; };
 		5577E86B251E86C2005250BC /* VerifiableCredentialTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiableCredentialTests.swift; sourceTree = "<group>"; };
@@ -275,6 +274,7 @@
 		55BEF4242587D28000C720BD /* IssuerIdTokenClaims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuerIdTokenClaims.swift; sourceTree = "<group>"; };
 		55BEF45C2589544500C720BD /* PinClaims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinClaims.swift; sourceTree = "<group>"; };
 		55BEF460258A5E0400C720BD /* IssuerIdToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuerIdToken.swift; sourceTree = "<group>"; };
+		55CA3A8027FB635300615CB6 /* VCSDKConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VCSDKConfiguration.swift; sourceTree = "<group>"; };
 		55CE4C5F25EEE99B00595CC7 /* CorrelationHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrelationHeader.swift; sourceTree = "<group>"; };
 		55FE6ED72697A06D00201EDC /* IssuanceCompletionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuanceCompletionResponse.swift; sourceTree = "<group>"; };
 		92E2998A252522C300B25BB6 /* VCJwt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = VCJwt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -674,9 +674,9 @@
 			isa = PBXGroup;
 			children = (
 				55793BCC255A070E007F7599 /* VCEntitiesConstants.swift */,
+				55CA3A8027FB635300615CB6 /* VCSDKConfiguration.swift */,
 				55575762251BC6CF009979AB /* JSONCodingKeys.swift */,
 				551F3062252E6E230081D5E7 /* Multihash.swift */,
-				5574956225E85987005A924B /* VCSDKConfiguration.swift */,
 				55CE4C5F25EEE99B00595CC7 /* CorrelationHeader.swift */,
 			);
 			path = util;
@@ -834,6 +834,7 @@
 				5573FEF525B8DE4A00282BC7 /* IONDocumentModel.swift in Sources */,
 				551F3068252E97000081D5E7 /* IdentifierCreator.swift in Sources */,
 				55253982252FDF89003202D5 /* KeyContainer.swift in Sources */,
+				55CA3A8127FB635300615CB6 /* VCSDKConfiguration.swift in Sources */,
 				5599D0CC26A07EE10037C131 /* IssuancePin.swift in Sources */,
 				559FC9AA25C9ABB500737F14 /* DomainLinkageCredentialValidator.swift in Sources */,
 				557BFC53251E665D005B5B24 /* IssuanceResponseFormatter.swift in Sources */,
@@ -924,7 +925,6 @@
 				55B4D2DE2787BE330086A9F1 /* PresentationExchangeFilter.swift in Sources */,
 				55B4D2DA2787BC7D0086A9F1 /* RequestedClaims.swift in Sources */,
 				55B4D2D82787BC220086A9F1 /* SupportedVerifiablePresentationFormats.swift in Sources */,
-				5574956325E85987005A924B /* VCSDKConfiguration.swift in Sources */,
 				559FC98C25C8BEC900737F14 /* DomainLinkageCredentialContent.swift in Sources */,
 				55575775251BC6CF009979AB /* IssuanceResponseClaims.swift in Sources */,
 			);

--- a/VCEntities/VCEntities/identifier/IdentifierCreator.swift
+++ b/VCEntities/VCEntities/identifier/IdentifierCreator.swift
@@ -14,7 +14,7 @@ public struct IdentifierCreator {
     let aliasComputer = AliasComputer()
     
     public init() {
-        self.init(cryptoOperations: CryptoOperations())
+        self.init(cryptoOperations: CryptoOperations(accessGroup: VCSDKConfiguration.sharedInstance.accessGroupIdentifier))
     }
     
     public init(cryptoOperations: CryptoOperating) {

--- a/VCEntities/VCEntities/identifier/KeyContainer.swift
+++ b/VCEntities/VCEntities/identifier/KeyContainer.swift
@@ -34,14 +34,18 @@ public struct KeyContainer {
         return keyReference.isValidKey()
     }
     
-    public func updateAccessGroup() throws {
+    public func migrateKey(fromAccessGroup oldAccessGroup: String?) throws {
         do {
-            try keyReference.updateAccessGroup()
-        } catch
+            try keyReference.migrateKey(fromAccessGroup: oldAccessGroup)
+        }
+        catch
         {
-            if case KeychainStoreError.itemNotFound = error {
+            if case KeychainStoreError.itemNotFound = error
+            {
                 throw KeyContainerError.noSigningKeyFoundInStorage
-            } else {
+            }
+            else
+            {
                 throw error
             }
         }

--- a/VCEntities/VCEntities/identifier/KeyContainer.swift
+++ b/VCEntities/VCEntities/identifier/KeyContainer.swift
@@ -5,10 +5,6 @@
 
 import VCCrypto
 
-public enum KeyContainerError: Error {
-    case noSigningKeyFoundInStorage
-}
-
 public struct KeyContainer {
     
     /// key reference to key in Secret Store
@@ -34,20 +30,8 @@ public struct KeyContainer {
         return keyReference.isValidKey()
     }
     
+    /// Migrate key from old access group to new one set in sdk config.
     public func migrateKey(fromAccessGroup oldAccessGroup: String?) throws {
-        do {
-            try keyReference.migrateKey(fromAccessGroup: oldAccessGroup)
-        }
-        catch
-        {
-            if case KeychainStoreError.itemNotFound = error
-            {
-                throw KeyContainerError.noSigningKeyFoundInStorage
-            }
-            else
-            {
-                throw error
-            }
-        }
+        try keyReference.migrateKey(fromAccessGroup: oldAccessGroup)
     }
 }

--- a/VCEntities/VCEntities/identifier/KeyContainer.swift
+++ b/VCEntities/VCEntities/identifier/KeyContainer.swift
@@ -5,6 +5,10 @@
 
 import VCCrypto
 
+public enum KeyContainerError: Error {
+    case noSigningKeyFoundInStorage
+}
+
 public struct KeyContainer {
     
     /// key reference to key in Secret Store
@@ -24,5 +28,22 @@ public struct KeyContainer {
     
     public func getId() -> UUID {
         return keyReference.id
+    }
+    
+    public func isValidKey() -> Bool {
+        return keyReference.isValidKey()
+    }
+    
+    public func updateAccessGroup() throws {
+        do {
+            try keyReference.updateAccessGroup()
+        } catch
+        {
+            if case KeychainStoreError.itemNotFound = error {
+                throw KeyContainerError.noSigningKeyFoundInStorage
+            } else {
+                throw error
+            }
+        }
     }
 }

--- a/VCEntities/VCEntities/identifier/KeyContainer.swift
+++ b/VCEntities/VCEntities/identifier/KeyContainer.swift
@@ -31,7 +31,7 @@ public struct KeyContainer {
     }
     
     /// Migrate key from old access group to new one set in sdk config.
-    public func migrateKey(fromAccessGroup oldAccessGroup: String?) throws {
-        try keyReference.migrateKey(fromAccessGroup: oldAccessGroup)
+    public func migrateKey(fromAccessGroup currentAccessGroup: String?) throws {
+        try keyReference.migrateKey(fromAccessGroup: currentAccessGroup)
     }
 }

--- a/VCEntities/VCEntities/logging/VCSDKLog.swift
+++ b/VCEntities/VCEntities/logging/VCSDKLog.swift
@@ -93,7 +93,7 @@ public struct VCSDKLog {
         }
     }
     
-    public func event(name: String, properties: [String: String]? = nil, measurements: [String: NSNumber]? = nil) {
+    func event(name: String, properties: [String: String]? = nil, measurements: [String: NSNumber]? = nil) {
         consumers.forEach { logger in
             logger.event(name: name, properties: properties, measurements: measurements)
         }

--- a/VCEntities/VCEntities/logging/VCSDKLog.swift
+++ b/VCEntities/VCEntities/logging/VCSDKLog.swift
@@ -93,7 +93,7 @@ public struct VCSDKLog {
         }
     }
     
-    func event(name: String, properties: [String: String]? = nil, measurements: [String: NSNumber]? = nil) {
+    public func event(name: String, properties: [String: String]? = nil, measurements: [String: NSNumber]? = nil) {
         consumers.forEach { logger in
             logger.event(name: name, properties: properties, measurements: measurements)
         }

--- a/VCEntities/VCEntities/util/VCSDKConfiguration.swift
+++ b/VCEntities/VCEntities/util/VCSDKConfiguration.swift
@@ -7,11 +7,11 @@ public struct VCSDKConfiguration {
     
     public static var sharedInstance = VCSDKConfiguration()
     
-    public var userAgentInfo: String = ""
+    public private(set) var accessGroupIdentifier: String? = nil
     
     private init() {}
     
-    public mutating func setUserAgentInfo(with info: String) {
-        self.userAgentInfo = info
+    mutating func setAccessGroupIdentifier(with id: String) {
+        self.accessGroupIdentifier = id
     }
 }

--- a/VCEntities/VCEntitiesTests/formatters/ExchangeRequestFormatterTests.swift
+++ b/VCEntities/VCEntitiesTests/formatters/ExchangeRequestFormatterTests.swift
@@ -24,7 +24,7 @@ class ExchangeRequestFormatterTests: XCTestCase {
         let signer = MockTokenSigner(x: "x", y: "y")
         formatter = ExchangeRequestFormatter(signer: signer)
         
-        let cryptoOperation = CryptoOperations(secretStore: SecretStoreMock())
+        let cryptoOperation = CryptoOperations(secretStore: SecretStoreMock(), accessGroup: nil)
         let key = try cryptoOperation.generateKey()
         
         let vc = VerifiableCredentialDescriptor(context: nil,

--- a/VCEntities/VCEntitiesTests/formatters/IssuanceResponseFormatterTests.swift
+++ b/VCEntities/VCEntitiesTests/formatters/IssuanceResponseFormatterTests.swift
@@ -25,7 +25,7 @@ class IssuanceResponseFormatterTests: XCTestCase {
         
         try self.mockResponse = IssuanceResponseContainer(from: self.contract, contractUri: self.expectedContractUrl)
         
-        let cryptoOperation = CryptoOperations(secretStore: SecretStoreMock())
+        let cryptoOperation = CryptoOperations(secretStore: SecretStoreMock(), accessGroup: nil)
         let key = try cryptoOperation.generateKey()
         
         let keyContainer = KeyContainer(keyReference: key, keyId: "keyId")

--- a/VCEntities/VCEntitiesTests/formatters/PresentationResponseFormatterTests.swift
+++ b/VCEntities/VCEntitiesTests/formatters/PresentationResponseFormatterTests.swift
@@ -27,7 +27,7 @@ class PresentationResponseFormatterTests: XCTestCase {
         
         self.mockResponse = try PresentationResponseContainer(from: self.request)
         
-        let cryptoOperation = CryptoOperations(secretStore: SecretStoreMock())
+        let cryptoOperation = CryptoOperations(secretStore: SecretStoreMock(), accessGroup: nil)
         let key = try cryptoOperation.generateKey()
         
         let keyContainer = KeyContainer(keyReference: key, keyId: "keyId")

--- a/VCEntities/VCEntitiesTests/mocks/MockCryptoOperations.swift
+++ b/VCEntities/VCEntitiesTests/mocks/MockCryptoOperations.swift
@@ -9,12 +9,12 @@ import VCToken
 @testable import VCEntities
 
 struct MockCryptoOperations: CryptoOperating {
-    
+
     static var generateKeyCallCount = 0
     let cryptoOperations: CryptoOperating
     
     init(secretStore: SecretStoring) {
-        self.cryptoOperations = CryptoOperations(secretStore: secretStore)
+        self.cryptoOperations = CryptoOperations(secretStore: secretStore, accessGroup: nil)
     }
     
     func generateKey() throws -> VCCryptoSecret {
@@ -22,7 +22,7 @@ struct MockCryptoOperations: CryptoOperating {
         return try self.cryptoOperations.generateKey()
     }
     
-    func retrieveKeyFromStorage(withId id: UUID) throws -> VCCryptoSecret {
+    func retrieveKeyFromStorage(withId id: UUID) -> VCCryptoSecret {
         return KeyId(id: id)
     }
 }

--- a/VCEntities/VCEntitiesTests/mocks/MockCryptoSecret.swift
+++ b/VCEntities/VCEntitiesTests/mocks/MockCryptoSecret.swift
@@ -7,9 +7,16 @@ import Foundation
 import VCCrypto
 
 struct MockCryptoSecret: VCCryptoSecret {
+    
     var id: UUID
     
     init(id: UUID) {
         self.id = id
     }
+    
+    func isValidKey() -> Bool {
+        return true
+    }
+    
+    func migrateKey(fromAccessGroup oldAccessGroup: String?) throws { }
 }

--- a/VCEntities/VCEntitiesTests/mocks/SecretStoreMock.swift
+++ b/VCEntities/VCEntitiesTests/mocks/SecretStoreMock.swift
@@ -10,11 +10,15 @@ internal class SecretStoreMock: SecretStoring {
     
     private var memoryStore = [UUID: Data]()
     
-    func getSecret(id: UUID, itemTypeCode: String) throws -> Data {
+    func getSecret(id: UUID, itemTypeCode: String, accessGroup: String?) throws -> Data {
         return memoryStore[id]!
     }
     
-    func saveSecret(id: UUID, itemTypeCode: String, value: inout Data) throws {
+    func saveSecret(id: UUID, itemTypeCode: String, accessGroup: String?, value: inout Data) throws {
         memoryStore[id] = value
+    }
+    
+    func deleteSecret(id: UUID, itemTypeCode: String, accessGroup: String?, value: inout Data) throws {
+        memoryStore.removeValue(forKey: id)
     }
 }

--- a/VCEntities/VCEntitiesTests/mocks/SecretStoreMock.swift
+++ b/VCEntities/VCEntitiesTests/mocks/SecretStoreMock.swift
@@ -18,7 +18,7 @@ internal class SecretStoreMock: SecretStoring {
         memoryStore[id] = value
     }
     
-    func deleteSecret(id: UUID, itemTypeCode: String, accessGroup: String?, value: inout Data) throws {
+    func deleteSecret(id: UUID, itemTypeCode: String, accessGroup: String?) throws {
         memoryStore.removeValue(forKey: id)
     }
 }

--- a/VCServices/VCServices.xcodeproj/project.pbxproj
+++ b/VCServices/VCServices.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		559FC9F925C9F35A00737F14 /* MockWellKnownConfigDocumentApiCalls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 559FC9F825C9F35A00737F14 /* MockWellKnownConfigDocumentApiCalls.swift */; };
 		559FCA3425C9FB7D00737F14 /* MockDomainLinkageCredentialValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 559FCA3325C9FB7D00737F14 /* MockDomainLinkageCredentialValidator.swift */; };
 		55AF7490252FBF5B006A8B25 /* MockVCCryptoSecret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AF748F252FBF5B006A8B25 /* MockVCCryptoSecret.swift */; };
+		55CA3A7F27FB60C900615CB6 /* VCSDKConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CA3A7E27FB60C900615CB6 /* VCSDKConfiguration.swift */; };
 		55DA76ED25BE36FF009C32E0 /* MockIssuanceApiCalls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DA76EC25BE36FF009C32E0 /* MockIssuanceApiCalls.swift */; };
 		55DA76F525BE3858009C32E0 /* MockExchangeApiCalls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DA76F425BE3858009C32E0 /* MockExchangeApiCalls.swift */; };
 		55DA76FA25BE390E009C32E0 /* MockPresentationApiCalls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DA76F925BE390E009C32E0 /* MockPresentationApiCalls.swift */; };
@@ -110,6 +111,7 @@
 		559FC9F825C9F35A00737F14 /* MockWellKnownConfigDocumentApiCalls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWellKnownConfigDocumentApiCalls.swift; sourceTree = "<group>"; };
 		559FCA3325C9FB7D00737F14 /* MockDomainLinkageCredentialValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDomainLinkageCredentialValidator.swift; sourceTree = "<group>"; };
 		55AF748F252FBF5B006A8B25 /* MockVCCryptoSecret.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockVCCryptoSecret.swift; sourceTree = "<group>"; };
+		55CA3A7E27FB60C900615CB6 /* VCSDKConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = VCSDKConfiguration.swift; path = ../../VCEntities/VCEntities/util/VCSDKConfiguration.swift; sourceTree = "<group>"; };
 		55DA76EC25BE36FF009C32E0 /* MockIssuanceApiCalls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockIssuanceApiCalls.swift; sourceTree = "<group>"; };
 		55DA76F425BE3858009C32E0 /* MockExchangeApiCalls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockExchangeApiCalls.swift; sourceTree = "<group>"; };
 		55DA76F925BE390E009C32E0 /* MockPresentationApiCalls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPresentationApiCalls.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				5531D3AF255F68280002CC0E /* PairwiseService.swift */,
 				555CE0922526AD0400C1C938 /* PresentationService.swift */,
 				5580583D25BFA2140048E6FA /* ServicesConstants.swift */,
+				55CA3A7E27FB60C900615CB6 /* VCSDKConfiguration.swift */,
 				550F1E3825101758009AF467 /* VCUseCase.h */,
 				550F1E3925101758009AF467 /* Info.plist */,
 			);
@@ -409,6 +412,7 @@
 			files = (
 				555BDB112530E6C9001E7A18 /* IdentifierDatabase.swift in Sources */,
 				555BDAEC2530AEC7001E7A18 /* VerifiableCredentialDataModel.xcdatamodeld in Sources */,
+				55CA3A7F27FB60C900615CB6 /* VCSDKConfiguration.swift in Sources */,
 				555BDB152530F024001E7A18 /* VerifiableCredentialSDK.swift in Sources */,
 				550F1E542510195A009AF467 /* IssuanceService.swift in Sources */,
 				55793BD7255C5A26007F7599 /* ExchangeService.swift in Sources */,

--- a/VCServices/VCServices/IdentifierService.swift
+++ b/VCServices/VCServices/IdentifierService.swift
@@ -53,15 +53,17 @@ public class IdentifierService {
     }
     
     /// updates access group for keys if it needs to be updated.
-    public func updateAccessGroupForKeys(for identifier: Identifier) throws {
-        try identifier.recoveryKey.updateAccessGroup()
-        try identifier.updateKey.updateAccessGroup()
+    public func migrateKeys(fromAccessGroup oldAccessGroup: String?) throws {
+        let identifier = try fetchMasterIdentifier()
+        try identifier.recoveryKey.migrateKey(fromAccessGroup: oldAccessGroup)
+        try identifier.updateKey.migrateKey(fromAccessGroup: oldAccessGroup)
         try identifier.didDocumentKeys.forEach { keyContainer in
-            try keyContainer.updateAccessGroup()
+            try keyContainer.migrateKey(fromAccessGroup: oldAccessGroup)
         }
     }
     
-    public func areKeysValid(for identifier: Identifier) -> Bool {
+    public func areKeysValid() throws -> Bool {
+        let identifier = try fetchMasterIdentifier()
         return identifier.recoveryKey.isValidKey() &&
                identifier.updateKey.isValidKey() &&
                (identifier.didDocumentKeys.first?.isValidKey() ?? false)

--- a/VCServices/VCServices/IdentifierService.swift
+++ b/VCServices/VCServices/IdentifierService.swift
@@ -53,12 +53,12 @@ public class IdentifierService {
     }
     
     /// updates access group for keys if it needs to be updated.
-    public func migrateKeys(fromAccessGroup oldAccessGroup: String?) throws {
+    public func migrateKeys(fromAccessGroup currentAccessGroup: String?) throws {
         let identifier = try fetchMasterIdentifier()
-        try identifier.recoveryKey.migrateKey(fromAccessGroup: oldAccessGroup)
-        try identifier.updateKey.migrateKey(fromAccessGroup: oldAccessGroup)
+        try identifier.recoveryKey.migrateKey(fromAccessGroup: currentAccessGroup)
+        try identifier.updateKey.migrateKey(fromAccessGroup: currentAccessGroup)
         try identifier.didDocumentKeys.forEach { keyContainer in
-            try keyContainer.migrateKey(fromAccessGroup: oldAccessGroup)
+            try keyContainer.migrateKey(fromAccessGroup: currentAccessGroup)
         }
     }
     

--- a/VCServices/VCServices/IdentifierService.swift
+++ b/VCServices/VCServices/IdentifierService.swift
@@ -53,20 +53,17 @@ public class IdentifierService {
     }
     
     /// updates access group for keys if it needs to be updated.
-    public func updateAccessGroupForKeysIfNeeded(for identifier: Identifier) throws -> Bool {
-        if (!identifier.recoveryKey.isValidKey() ||
-            !identifier.updateKey.isValidKey() ||
-            !(identifier.didDocumentKeys.first?.isValidKey() ?? false)) {
-
-                try identifier.recoveryKey.updateAccessGroup()
-                try identifier.updateKey.updateAccessGroup()
-                try identifier.didDocumentKeys.forEach { keyContainer in
-                    try keyContainer.updateAccessGroup()
-                }
-                
-                return true
+    public func updateAccessGroupForKeys(for identifier: Identifier) throws {
+        try identifier.recoveryKey.updateAccessGroup()
+        try identifier.updateKey.updateAccessGroup()
+        try identifier.didDocumentKeys.forEach { keyContainer in
+            try keyContainer.updateAccessGroup()
         }
-        
-        return false
+    }
+    
+    public func areKeysValid(for identifier: Identifier) -> Bool {
+        return identifier.recoveryKey.isValidKey() &&
+               identifier.updateKey.isValidKey() &&
+               (identifier.didDocumentKeys.first?.isValidKey() ?? false)
     }
 }

--- a/VCServices/VCServices/IdentifierService.swift
+++ b/VCServices/VCServices/IdentifierService.swift
@@ -51,4 +51,22 @@ public class IdentifierService {
         sdkLog.logVerbose(message: "Created Identifier with alias:\(identifier.alias)")
         return identifier
     }
+    
+    /// updates access group for keys if it needs to be updated.
+    public func updateAccessGroupForKeysIfNeeded(for identifier: Identifier) throws -> Bool {
+        if (!identifier.recoveryKey.isValidKey() ||
+            !identifier.updateKey.isValidKey() ||
+            !(identifier.didDocumentKeys.first?.isValidKey() ?? false)) {
+
+                try identifier.recoveryKey.updateAccessGroup()
+                try identifier.updateKey.updateAccessGroup()
+                try identifier.didDocumentKeys.forEach { keyContainer in
+                    try keyContainer.updateAccessGroup()
+                }
+                
+                return true
+        }
+        
+        return false
+    }
 }

--- a/VCServices/VCServices/VerifiableCredentialSDK.swift
+++ b/VCServices/VCServices/VerifiableCredentialSDK.swift
@@ -5,26 +5,62 @@
 
 import VCEntities
 
+public enum VerifiableCredentialSDKInitializationStatus
+{
+    case masterIdentifierCreated
+    case masterIdentifierCreatedWithError(error: Error)
+    case accessGroupForKeysUpdated
+    case success
+    case error(error: Error)
+}
+
 public class VerifiableCredentialSDK {
+    
+    static let identifierService = IdentifierService()
     
     /// Initialized the SDK.
     /// Returns: TRUE, if needed to create Master Identifier
     ///          FALSE, if Master Identifier is able to be fetched (included private keys from KeyStore)
     public static func initialize(logConsumer: VCLogConsumer = DefaultVCLogConsumer(),
-                                  userAgentInfo: String = "") throws -> Bool {
+                                  accessGroupIdentifier: String? = nil) -> VerifiableCredentialSDKInitializationStatus {
 
         VCSDKLog.sharedInstance.add(consumer: logConsumer)
-        VCSDKConfiguration.sharedInstance.setUserAgentInfo(with: userAgentInfo)
         
-        let identifierService = IdentifierService()
+        if let accessGroupIdentifier = accessGroupIdentifier {
+            VCSDKConfiguration.sharedInstance.setAccessGroupIdentifier(with: accessGroupIdentifier)
+        }
         
         do {
-            _ = try identifierService.fetchMasterIdentifier()
-            return false
+            let identifier = try identifierService.fetchMasterIdentifier()
+            if try identifierService.updateAccessGroupForKeysIfNeeded(for: identifier) {
+                return .accessGroupForKeysUpdated
+            }
         } catch {
-            VCSDKLog.sharedInstance.logWarning(message: "Failed to fetch master identifier with: \(String(describing: error))")
+            
+            if error is IdentifierDatabaseError {
+                VCSDKLog.sharedInstance.logWarning(message: "Failed to fetch master identifier with: \(String(describing: error))")
+                return createNewIdentifier()
+            }
+            
+            if case KeyContainerError.noSigningKeyFoundInStorage = error
+            {
+                VCSDKLog.sharedInstance.logWarning(message: "Failed find signing keys in storage with: \(String(describing: error))")
+                let _ = createNewIdentifier()
+                return .masterIdentifierCreatedWithError(error: error)
+            }
+            
+            return .error(error: error)
+        }
+        
+        return .success
+    }
+    
+    private static func createNewIdentifier() -> VerifiableCredentialSDKInitializationStatus {
+        do {
             _ = try identifierService.createAndSaveIdentifier(forId: VCEntitiesConstants.MASTER_ID, andRelyingParty: VCEntitiesConstants.MASTER_ID)
-            return true
+            return .masterIdentifierCreated
+        } catch {
+            return .error(error: error)
         }
     }
 }

--- a/VCServices/VCServices/VerifiableCredentialSDK.swift
+++ b/VCServices/VCServices/VerifiableCredentialSDK.swift
@@ -5,10 +5,10 @@
 
 import VCEntities
 
-public enum VerifiableCredentialSDKInitializationStatus
+public enum VCSDKInitStatus
 {
-    case masterIdentifierCreated
-    case masterIdentifierCreatedWithError(error: Error)
+    case firstTimeMasterIdentifierCreated
+    case newMasterIdentifierCreated
     case accessGroupForKeysUpdated
     case success
     case error(error: Error)
@@ -22,43 +22,56 @@ public class VerifiableCredentialSDK {
     /// Returns: TRUE, if needed to create Master Identifier
     ///          FALSE, if Master Identifier is able to be fetched (included private keys from KeyStore)
     public static func initialize(logConsumer: VCLogConsumer = DefaultVCLogConsumer(),
-                                  accessGroupIdentifier: String? = nil) -> VerifiableCredentialSDKInitializationStatus {
+                                  accessGroupIdentifier: String? = nil) -> VCSDKInitStatus {
 
         VCSDKLog.sharedInstance.add(consumer: logConsumer)
         
+        
+        /// Get access group identifier for app.
         if let accessGroupIdentifier = accessGroupIdentifier {
             VCSDKConfiguration.sharedInstance.setAccessGroupIdentifier(with: accessGroupIdentifier)
         }
         
+        /// Try to fetch master identifier from storage.
+        var identifier: Identifier
         do {
-            let identifier = try identifierService.fetchMasterIdentifier()
-            if try identifierService.updateAccessGroupForKeysIfNeeded(for: identifier) {
+            
+            identifier = try identifierService.fetchMasterIdentifier()
+            
+        } catch {
+            
+            /// If unable to fetch master identifier, create a new one.
+            VCSDKLog.sharedInstance.logWarning(message: "Failed to fetch master identifier with: \(String(describing: error))")
+            return createNewIdentifier(status: .firstTimeMasterIdentifierCreated)
+            
+        }
+        
+        /// Make sure keys are valid for master identifier, if they are not valid, update access group.
+        do {
+            if !identifierService.areKeysValid(for: identifier) {
+                try identifierService.updateAccessGroupForKeys(for: identifier)
                 return .accessGroupForKeysUpdated
             }
         } catch {
             
-            if error is IdentifierDatabaseError {
-                VCSDKLog.sharedInstance.logWarning(message: "Failed to fetch master identifier with: \(String(describing: error))")
-                return createNewIdentifier()
-            }
-            
+            /// if keys are not found in storage, create a new master identifier.
             if case KeyContainerError.noSigningKeyFoundInStorage = error
             {
                 VCSDKLog.sharedInstance.logWarning(message: "Failed find signing keys in storage with: \(String(describing: error))")
-                let _ = createNewIdentifier()
-                return .masterIdentifierCreatedWithError(error: error)
+                return createNewIdentifier(status: .newMasterIdentifierCreated)
             }
             
             return .error(error: error)
         }
         
+        /// VC sdk initialization successful.
         return .success
     }
     
-    private static func createNewIdentifier() -> VerifiableCredentialSDKInitializationStatus {
+    private static func createNewIdentifier(status: VCSDKInitStatus) -> VCSDKInitStatus {
         do {
             _ = try identifierService.createAndSaveIdentifier(forId: VCEntitiesConstants.MASTER_ID, andRelyingParty: VCEntitiesConstants.MASTER_ID)
-            return .masterIdentifierCreated
+            return status
         } catch {
             return .error(error: error)
         }

--- a/VCServices/VCServices/VerifiableCredentialSDK.swift
+++ b/VCServices/VCServices/VerifiableCredentialSDK.swift
@@ -5,12 +5,19 @@
 
 import VCEntities
 
+/// status of a successful initialization
 public enum VCSDKInitStatus
 {
     case newMasterIdentifierCreated
     case success
 }
 
+/// initialization errors.
+public enum VCSDKInitError: Error {
+    case invalidKeys
+}
+
+/// Class used to Initialize the SDK.
 public class VerifiableCredentialSDK {
     
     static let identifierService = IdentifierService()
@@ -32,6 +39,10 @@ public class VerifiableCredentialSDK {
         do {
             
             _ = try identifierService.fetchMasterIdentifier()
+            
+            if try !identifierService.areKeysValid() {
+                return .failure(VCSDKInitError.invalidKeys)
+            }
             
         } catch {
             

--- a/VCServices/VCServices/VerifiableCredentialSDK.swift
+++ b/VCServices/VCServices/VerifiableCredentialSDK.swift
@@ -29,10 +29,9 @@ public class VerifiableCredentialSDK {
         }
         
         /// Try to fetch master identifier from storage.
-        var identifier: Identifier
         do {
             
-            identifier = try identifierService.fetchMasterIdentifier()
+            _ = try identifierService.fetchMasterIdentifier()
             
         } catch {
             

--- a/VCServices/VCServices/coreData/IdentifierDatabase.swift
+++ b/VCServices/VCServices/coreData/IdentifierDatabase.swift
@@ -112,7 +112,7 @@ struct IdentifierDatabase {
             throw IdentifierDatabaseError.unableToFetchMasterIdentifier
         }
         
-        let keyRef = try cryptoOperations.retrieveKeyFromStorage(withId: keyUUID)
+        let keyRef = cryptoOperations.retrieveKeyFromStorage(withId: keyUUID)
         return KeyContainer(keyReference: keyRef, keyId: keyId)
     }
 }

--- a/VCServices/VCServices/coreData/IdentifierDatabase.swift
+++ b/VCServices/VCServices/coreData/IdentifierDatabase.swift
@@ -23,7 +23,7 @@ struct IdentifierDatabase {
     private let cryptoOperations: CryptoOperating
     
     init() {
-        self.cryptoOperations = CryptoOperations()
+        self.cryptoOperations = CryptoOperations(accessGroup: VCSDKConfiguration.sharedInstance.accessGroupIdentifier)
     }
     
     init(cryptoOperations: CryptoOperating) {

--- a/VCServices/VCServicesTests/IdentifierDatabaseTests.swift
+++ b/VCServices/VCServicesTests/IdentifierDatabaseTests.swift
@@ -16,7 +16,7 @@ class IdentifierDatabaseTests: XCTestCase {
     var identifierDB: IdentifierDatabase!
     
     override func setUpWithError() throws {
-        let cryptoOperations = CryptoOperations()
+        let cryptoOperations = CryptoOperations(accessGroup: nil)
         identifierDB = IdentifierDatabase(cryptoOperations: cryptoOperations)
         try CoreDataManager.sharedInstance.deleteAllIdentifiers()
         identifierCreator = IdentifierCreator(cryptoOperations: cryptoOperations)

--- a/VCServices/VCServicesTests/mocks/MockVCCryptoSecret.swift
+++ b/VCServices/VCServicesTests/mocks/MockVCCryptoSecret.swift
@@ -6,5 +6,12 @@
 import VCCrypto
 
 struct MockVCCryptoSecret: VCCryptoSecret {
+    
+    func isValidKey() -> Bool {
+        return true
+    }
+    
+    func migrateKey(fromAccessGroup oldAccessGroup: String?) throws { }
+    
     var id: UUID = UUID()
 }

--- a/VCServices/VCServicesTests/mocks/SecretStoreMock.swift
+++ b/VCServices/VCServicesTests/mocks/SecretStoreMock.swift
@@ -19,7 +19,7 @@ internal class SecretStoreMock: SecretStoring {
         memoryStore[id] = value
     }
     
-    func deleteSecret(id: UUID, itemTypeCode: String, accessGroup: String?, value: inout Data) throws {
+    func deleteSecret(id: UUID, itemTypeCode: String, accessGroup: String?) throws {
         print("deletingSecret... " + id.uuidString)
         memoryStore.removeValue(forKey: id)
     }

--- a/VCServices/VCServicesTests/mocks/SecretStoreMock.swift
+++ b/VCServices/VCServicesTests/mocks/SecretStoreMock.swift
@@ -6,16 +6,21 @@
 import Foundation
 @testable import VCCrypto
 internal class SecretStoreMock: SecretStoring {
-    
+
     private var memoryStore = [UUID: Data]()
     
-    func getSecret(id: UUID, itemTypeCode: String) throws -> Data {
+    func getSecret(id: UUID, itemTypeCode: String, accessGroup: String?) throws -> Data {
         print("gettingSecret... " + id.uuidString)
         return memoryStore[id]!
     }
     
-    func saveSecret(id: UUID, itemTypeCode: String, value: inout Data) throws {
+    func saveSecret(id: UUID, itemTypeCode: String, accessGroup: String?, value: inout Data) throws {
         print("savingSecret... " + id.uuidString)
         memoryStore[id] = value
+    }
+    
+    func deleteSecret(id: UUID, itemTypeCode: String, accessGroup: String?, value: inout Data) throws {
+        print("deletingSecret... " + id.uuidString)
+        memoryStore.removeValue(forKey: id)
     }
 }

--- a/VCToken/VCToken/JwsToken.swift
+++ b/VCToken/VCToken/JwsToken.swift
@@ -6,7 +6,6 @@
 import VCCrypto
 
 public enum JwsTokenError: Error {
-    case signingKeyNotFoundInStorage
     case unsupportedAlgorithm(name: String?)
 }
 
@@ -63,15 +62,7 @@ public struct JwsToken<T: Claims> {
     }
     
     public mutating func sign(using signer: TokenSigning, withSecret secret: VCCryptoSecret) throws {
-        do {
-            self.signature = try signer.sign(token: self, withSecret: secret)
-        } catch {
-            /// rewrap errror of KeyChainStoreError to deal with this error a layer up.
-            if case KeychainStoreError.itemNotFound = error
-            {
-                throw JwsTokenError.signingKeyNotFoundInStorage
-            }
-        }
+        self.signature = try signer.sign(token: self, withSecret: secret)
     }
     
     public func verify(using verifier: TokenVerifying, withPublicKey key: ECPublicJwk) throws -> Bool {

--- a/VCToken/VCToken/KeyId.swift
+++ b/VCToken/VCToken/KeyId.swift
@@ -6,7 +6,7 @@
 import VCCrypto
 
 public struct KeyId: VCCryptoSecret {
-
+    
     public let id: UUID
     
     public init(id: UUID) {
@@ -17,5 +17,5 @@ public struct KeyId: VCCryptoSecret {
         return true
     }
     
-    public func updateAccessGroup() throws { }
+    public func migrateKey(fromAccessGroup oldAccessGroup: String?) throws { }
 }

--- a/VCToken/VCToken/KeyId.swift
+++ b/VCToken/VCToken/KeyId.swift
@@ -6,9 +6,16 @@
 import VCCrypto
 
 public struct KeyId: VCCryptoSecret {
+
     public let id: UUID
     
     public init(id: UUID) {
         self.id = id
     }
+    
+    public func isValidKey() -> Bool {
+        return true
+    }
+    
+    public func updateAccessGroup() throws { }
 }

--- a/VCToken/VCTokenTests/mocks/MockAlgorithm.swift
+++ b/VCToken/VCTokenTests/mocks/MockAlgorithm.swift
@@ -11,6 +11,12 @@ enum MockError: Error {
 }
 
 struct MockVCCryptoSecret: VCCryptoSecret {
+    func isValidKey() -> Bool {
+        true
+    }
+    
+    func migrateKey(fromAccessGroup oldAccessGroup: String?) throws {}
+    
     let id: UUID
 }
 


### PR DESCRIPTION
**Problem:**
There was a very very rare error where the keys in default access group were getting deleted by app. 


**Solution:**
Our solution is to save all keys related to VC under a configurable access group.
**We also changed the SDK initialization external api to make it more clear.** 


**Validation:**
All tests pass, and works end to end.


**Type of change:**
- [X] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [X] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.
