### PR TITLE
Restore internal `*Secret` interfaces

### DIFF
--- a/VCCrypto/VCCrypto.xcodeproj/project.pbxproj
+++ b/VCCrypto/VCCrypto.xcodeproj/project.pbxproj
@@ -641,7 +641,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACH_O_TYPE = staticlib;
+				MACH_O_TYPE = mh_dylib;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.VCCrypto;
 				PRODUCT_NAME = VCCrypto;
 				SKIP_INSTALL = YES;
@@ -672,7 +672,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACH_O_TYPE = staticlib;
+				MACH_O_TYPE = mh_dylib;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.VCCrypto;
 				PRODUCT_NAME = VCCrypto;
 				SKIP_INSTALL = YES;

--- a/VCCrypto/VCCrypto/Algo/HmacSha2.swift
+++ b/VCCrypto/VCCrypto/Algo/HmacSha2.swift
@@ -8,6 +8,7 @@ import CommonCrypto
 
 enum HmacSha2Error: Error {
     case invalidMessage
+    case invalidSecret
     case invalidAlgorithm
 }
 
@@ -39,6 +40,7 @@ public struct HmacSha2 {
 
         // Look for an early out
         guard message.count > 0 else { throw HmacSha2Error.invalidMessage }
+        guard secret is Secret else { throw HmacSha2Error.invalidSecret }
 
         // Apply
         let ccHmacAlg = self.algorithm
@@ -46,7 +48,7 @@ public struct HmacSha2 {
         try message.withUnsafeBytes { (messagePtr: UnsafeRawBufferPointer) in
             let messageBytes = messagePtr.bindMemory(to: UInt8.self)
             
-            try secret.withUnsafeBytes { (secretPtr: UnsafeRawBufferPointer) in
+            try (secret as! Secret).withUnsafeBytes { (secretPtr: UnsafeRawBufferPointer) in
                 let secretBytes = secretPtr.bindMemory(to: UInt8.self)
                 
                 CCHmac(ccHmacAlg, secretBytes.baseAddress, secretBytes.count, messageBytes.baseAddress, messageBytes.count, &mac)

--- a/VCCrypto/VCCrypto/Keys/EphemeralSecret.swift
+++ b/VCCrypto/VCCrypto/Keys/EphemeralSecret.swift
@@ -45,10 +45,12 @@ public final class EphemeralSecret: Secret {
     public init(with secret: VCCryptoSecret) throws
     {
         value = Data()
-        try secret.withUnsafeBytes { secretPtr in
-            if let baseAddress = secretPtr.baseAddress, secretPtr.count > 0 {
-                let bytes = baseAddress.assumingMemoryBound(to: UInt8.self)
-                value.append(bytes, count: secretPtr.count)
+        if let internalSecret = secret as? Secret {
+            try internalSecret.withUnsafeBytes { secretPtr in
+                if let baseAddress = secretPtr.baseAddress, secretPtr.count > 0 {
+                    let bytes = baseAddress.assumingMemoryBound(to: UInt8.self)
+                    value.append(bytes, count: secretPtr.count)
+                }
             }
         }
         self.id = secret.id

--- a/VCCrypto/VCCrypto/Keys/Secret.swift
+++ b/VCCrypto/VCCrypto/Keys/Secret.swift
@@ -18,12 +18,12 @@ public protocol VCCryptoSecret {
     func isValidKey() throws
     
     func migrateKey(fromAccessGroup currentAccessGroup: String?) throws
-    
-    /// Invokes the closure passed as a param with a buffer pointer to the raw bytes of the secret.
-    func withUnsafeBytes(_ body: (UnsafeRawBufferPointer) throws -> Void) throws
 }
 
 protocol InternalSecret  {
+    
+    /// Invokes the closure passed as a param with a buffer pointer to the raw bytes of the secret. 
+    func withUnsafeBytes(_ body: (UnsafeRawBufferPointer) throws -> Void) throws
     
     /// The 4 characters representing the secret type in the store. This correspond to kSecAttrType in keychain
     static var itemTypeCode: String { get }

--- a/VCCrypto/VCCryptoTests/AesTests.swift
+++ b/VCCrypto/VCCryptoTests/AesTests.swift
@@ -35,7 +35,7 @@ class AesTests: XCTestCase {
         
         let result = try fixture.unwrap(wrapped: wrapped, using: kek)
         var data = Data()
-        try result.withUnsafeBytes{ resultPtr in
+        try (result as! Secret).withUnsafeBytes{ resultPtr in
             data.append(resultPtr.bindMemory(to: UInt8.self))
         }
         XCTAssertEqual(data, cek.value)

--- a/VCCrypto/VCCryptoTests/PbkdfTests.swift
+++ b/VCCrypto/VCCryptoTests/PbkdfTests.swift
@@ -24,7 +24,7 @@ class PbkdfTests : XCTestCase {
         
         // Validate
         var data = Data()
-        try derived.withUnsafeBytes { (derivedPtr) in
+        try (derived as! Secret).withUnsafeBytes { (derivedPtr) in
             data.append(derivedPtr.bindMemory(to: UInt8.self))
         }
         XCTAssertEqual(Data(expected), data)

--- a/VCEntities/VCEntities.xcodeproj/project.pbxproj
+++ b/VCEntities/VCEntities.xcodeproj/project.pbxproj
@@ -1202,7 +1202,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACH_O_TYPE = staticlib;
+				MACH_O_TYPE = mh_dylib;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.VCEntities;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1232,7 +1232,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACH_O_TYPE = staticlib;
+				MACH_O_TYPE = mh_dylib;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.VCEntities;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/VCNetworking/VCNetworking.xcodeproj/project.pbxproj
+++ b/VCNetworking/VCNetworking.xcodeproj/project.pbxproj
@@ -863,7 +863,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACH_O_TYPE = staticlib;
+				MACH_O_TYPE = mh_dylib;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.VCNetworking;
 				PRODUCT_NAME = VCNetworking;
 				SKIP_INSTALL = YES;
@@ -893,7 +893,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACH_O_TYPE = staticlib;
+				MACH_O_TYPE = mh_dylib;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.VCNetworking;
 				PRODUCT_NAME = VCNetworking;
 				SKIP_INSTALL = YES;

--- a/VCToken/VCToken.xcodeproj/project.pbxproj
+++ b/VCToken/VCToken.xcodeproj/project.pbxproj
@@ -488,7 +488,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACH_O_TYPE = staticlib;
+				MACH_O_TYPE = mh_dylib;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.VCToken;
 				PRODUCT_NAME = VCToken;
 				SKIP_INSTALL = YES;
@@ -516,7 +516,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACH_O_TYPE = staticlib;
+				MACH_O_TYPE = mh_dylib;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.VCToken;
 				PRODUCT_NAME = VCToken;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
**Problem:**
In a prior [PR](https://github.com/microsoft/VerifiableCredential-SDK-iOS/pull/128), an internal interface was exposed to work-around a problem wherein cross-module type casts would fail in an app using this SDK, c.f. https://forums.swift.org/t/error-casting-fails-when-dependency-integrated-as-static-library/30305


**Solution:**
Change the build settings such that modules that expose types which may subject to casts are built as dynamic, and not static, libraries, and then restore the internal interface


**Validation:**
Tested issuance, presentation, import and export scenarios on device (testing via Test Flight pending)

**Type of change:**
- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
T.B.D.