### PR TITLE
Update to new discovery url and option to inject url into SDK instead of hardcoded

### DIFF
--- a/VCEntities/VCEntities.xcodeproj/project.pbxproj
+++ b/VCEntities/VCEntities.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		5531D3B2255F6B6E0002CC0E /* ResponseContaining.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5531D3B1255F6B6E0002CC0E /* ResponseContaining.swift */; };
 		55379AD725A8DF7A0048600A /* PresentationRequestValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55379AD625A8DF7A0048600A /* PresentationRequestValidator.swift */; };
 		553D4C472821D89D00FD39A6 /* IssuanceRequestValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 553D4C462821D89D00FD39A6 /* IssuanceRequestValidator.swift */; };
+		5540226428C9587600C85C6D /* VCSDKConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5540226328C9587600C85C6D /* VCSDKConfiguration.swift */; };
 		55575738251BC575009979AB /* VCEntities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5557572E251BC575009979AB /* VCEntities.framework */; };
 		5557573F251BC575009979AB /* VCEntities.h in Headers */ = {isa = PBXBuildFile; fileRef = 55575731251BC575009979AB /* VCEntities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55575763251BC6CF009979AB /* AttestationsDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5557574B251BC6CE009979AB /* AttestationsDescriptor.swift */; };
@@ -142,7 +143,6 @@
 		55BEF4252587D28000C720BD /* IssuerIdTokenClaims.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BEF4242587D28000C720BD /* IssuerIdTokenClaims.swift */; };
 		55BEF45D2589544500C720BD /* PinClaims.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BEF45C2589544500C720BD /* PinClaims.swift */; };
 		55BEF461258A5E0400C720BD /* IssuerIdToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BEF460258A5E0400C720BD /* IssuerIdToken.swift */; };
-		55CA3A8127FB635300615CB6 /* VCSDKConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CA3A8027FB635300615CB6 /* VCSDKConfiguration.swift */; };
 		55CE4C6025EEE99B00595CC7 /* CorrelationHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CE4C5F25EEE99B00595CC7 /* CorrelationHeader.swift */; };
 		55FE6ED82697A06D00201EDC /* IssuanceCompletionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FE6ED72697A06D00201EDC /* IssuanceCompletionResponse.swift */; };
 /* End PBXBuildFile section */
@@ -196,6 +196,7 @@
 		5531D3B1255F6B6E0002CC0E /* ResponseContaining.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseContaining.swift; sourceTree = "<group>"; };
 		55379AD625A8DF7A0048600A /* PresentationRequestValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationRequestValidator.swift; sourceTree = "<group>"; };
 		553D4C462821D89D00FD39A6 /* IssuanceRequestValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuanceRequestValidator.swift; sourceTree = "<group>"; };
+		5540226328C9587600C85C6D /* VCSDKConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VCSDKConfiguration.swift; sourceTree = "<group>"; };
 		5557572E251BC575009979AB /* VCEntities.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VCEntities.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		55575731251BC575009979AB /* VCEntities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VCEntities.h; sourceTree = "<group>"; };
 		55575732251BC575009979AB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -299,7 +300,6 @@
 		55BEF4242587D28000C720BD /* IssuerIdTokenClaims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuerIdTokenClaims.swift; sourceTree = "<group>"; };
 		55BEF45C2589544500C720BD /* PinClaims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinClaims.swift; sourceTree = "<group>"; };
 		55BEF460258A5E0400C720BD /* IssuerIdToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuerIdToken.swift; sourceTree = "<group>"; };
-		55CA3A8027FB635300615CB6 /* VCSDKConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VCSDKConfiguration.swift; sourceTree = "<group>"; };
 		55CE4C5F25EEE99B00595CC7 /* CorrelationHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrelationHeader.swift; sourceTree = "<group>"; };
 		55FE6ED72697A06D00201EDC /* IssuanceCompletionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuanceCompletionResponse.swift; sourceTree = "<group>"; };
 		92E2998A252522C300B25BB6 /* VCJwt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = VCJwt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -750,8 +750,8 @@
 		55AF7481252F6803006A8B25 /* util */ = {
 			isa = PBXGroup;
 			children = (
+				5540226328C9587600C85C6D /* VCSDKConfiguration.swift */,
 				55793BCC255A070E007F7599 /* VCEntitiesConstants.swift */,
-				55CA3A8027FB635300615CB6 /* VCSDKConfiguration.swift */,
 				55575762251BC6CF009979AB /* JSONCodingKeys.swift */,
 				551F3062252E6E230081D5E7 /* Multihash.swift */,
 				55CE4C5F25EEE99B00595CC7 /* CorrelationHeader.swift */,
@@ -914,7 +914,6 @@
 				5573FEF525B8DE4A00282BC7 /* IONDocumentModel.swift in Sources */,
 				551F3068252E97000081D5E7 /* IdentifierCreator.swift in Sources */,
 				55253982252FDF89003202D5 /* KeyContainer.swift in Sources */,
-				55CA3A8127FB635300615CB6 /* VCSDKConfiguration.swift in Sources */,
 				5599D0CC26A07EE10037C131 /* IssuancePin.swift in Sources */,
 				559FC9AA25C9ABB500737F14 /* DomainLinkageCredentialValidator.swift in Sources */,
 				557BFC53251E665D005B5B24 /* IssuanceResponseFormatter.swift in Sources */,
@@ -990,6 +989,7 @@
 				55793BCD255A070E007F7599 /* VCEntitiesConstants.swift in Sources */,
 				5584E4A2252565D900A9DE58 /* IssuanceMetadata.swift in Sources */,
 				5518CC68252645D000C7A21B /* PresentationSubmission.swift in Sources */,
+				5540226428C9587600C85C6D /* VCSDKConfiguration.swift in Sources */,
 				5531D3B2255F6B6E0002CC0E /* ResponseContaining.swift in Sources */,
 				5557576A251BC6CF009979AB /* Contract.swift in Sources */,
 				5517D28E25B90D0A00FBD239 /* ExchangeRequestClaims.swift in Sources */,

--- a/VCEntities/VCEntities/util/VCSDKConfiguration.swift
+++ b/VCEntities/VCEntities/util/VCSDKConfiguration.swift
@@ -11,7 +11,7 @@ public struct VCSDKConfiguration: VCSDKConfigurable {
     
     public private(set) var accessGroupIdentifier: String?
     
-    public private(set) var discoveryUrl: String?
+    public private(set) var discoveryUrl: String = "https://discover.did.msidentity.com/v1.0/identifiers"
     
     private init() {}
     

--- a/VCEntities/VCEntities/util/VCSDKConfiguration.swift
+++ b/VCEntities/VCEntities/util/VCSDKConfiguration.swift
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
 import VCCrypto
 
 public struct VCSDKConfiguration: VCSDKConfigurable {

--- a/VCEntities/VCEntities/util/VCSDKConfiguration.swift
+++ b/VCEntities/VCEntities/util/VCSDKConfiguration.swift
@@ -1,8 +1,3 @@
-/*---------------------------------------------------------------------------------------------
-*  Copyright (c) Microsoft Corporation. All rights reserved.
-*  Licensed under the MIT License. See License.txt in the project root for license information.
-*--------------------------------------------------------------------------------------------*/
-
 import VCCrypto
 
 public struct VCSDKConfiguration: VCSDKConfigurable {
@@ -11,9 +6,15 @@ public struct VCSDKConfiguration: VCSDKConfigurable {
     
     public private(set) var accessGroupIdentifier: String?
     
+    public private(set) var discoveryUrl: String?
+    
     private init() {}
     
-    mutating func setAccessGroupIdentifier(with id: String) {
+    public mutating func setAccessGroupIdentifier(with id: String) {
         self.accessGroupIdentifier = id
+    }
+    
+    public mutating func setDiscoveryUrl(with url: String) {
+        self.discoveryUrl = url
     }
 }

--- a/VCNetworking/VCNetworking/NetworkingConstants.swift
+++ b/VCNetworking/VCNetworking/NetworkingConstants.swift
@@ -10,10 +10,6 @@ struct Constants {
     static let JSON = "application/json"
     static let CONTENT_TYPE = "Content-Type"
     
-    // Beta Discovery Service URL
-    static let DISCOVERY_URL = "https://beta.discover.did.microsoft.com"
-    static let DISCOVERY_URL_PATH = "/1.0/identifiers/"
-    
     // Header values for signed contracts
     static let SIGNED_CONTRACT_HEADER_FIELD = "x-ms-sign-contract"
     static let SIGNED_CONTRACT_HEADER_VALUE = "true"

--- a/VCNetworking/VCNetworking/NetworkingError.swift
+++ b/VCNetworking/VCNetworking/NetworkingError.swift
@@ -6,7 +6,7 @@
 public enum NetworkingError: Error, Equatable {
     case badRequest(withBody: String, statusCode: Int)
     case forbidden(withBody: String, statusCode: Int)
-    case invalidUrl(withUrl: String)
+    case invalidUrl(withUrl: String?)
     case notFound(withBody: String, statusCode: Int)
     case serverError(withBody: String, statusCode: Int)
     case unauthorized(withBody: String, statusCode: Int)

--- a/VCNetworking/VCNetworking/operations/fetch/FetchDIDDocumentOperation.swift
+++ b/VCNetworking/VCNetworking/operations/fetch/FetchDIDDocumentOperation.swift
@@ -19,14 +19,19 @@ class FetchDIDDocumentOperation: InternalNetworkOperation {
          andCorrelationVector correlationVector: CorrelationHeader? = nil,
          session: URLSession = URLSession()) throws {
         
-        guard var urlComponents = URLComponents(string: Constants.DISCOVERY_URL) else {
-            throw NetworkingError.invalidUrl(withUrl: Constants.DISCOVERY_URL)
+        guard let discoveryUrl = VCSDKConfiguration.sharedInstance.discoveryUrl,
+              var urlComponents = URLComponents(string: discoveryUrl) else {
+            throw NetworkingError.invalidUrl(withUrl: VCSDKConfiguration.sharedInstance.discoveryUrl)
         }
         
-        urlComponents.path = Constants.DISCOVERY_URL_PATH + identifier
+        if urlComponents.path.last == "/" {
+            urlComponents.path = urlComponents.path + identifier
+        } else {
+            urlComponents.path = urlComponents.path + "/" + identifier
+        }
         
         guard let url = urlComponents.url else {
-            throw NetworkingError.invalidUrl(withUrl: urlComponents.string ?? Constants.DISCOVERY_URL)
+            throw NetworkingError.invalidUrl(withUrl: urlComponents.string ?? discoveryUrl)
         }
         
         self.urlRequest = URLRequest(url: url)

--- a/VCNetworking/VCNetworking/operations/fetch/FetchDIDDocumentOperation.swift
+++ b/VCNetworking/VCNetworking/operations/fetch/FetchDIDDocumentOperation.swift
@@ -24,11 +24,8 @@ class FetchDIDDocumentOperation: InternalNetworkOperation {
             throw NetworkingError.invalidUrl(withUrl: VCSDKConfiguration.sharedInstance.discoveryUrl)
         }
         
-        if urlComponents.path.last == "/" {
-            urlComponents.path = urlComponents.path + identifier
-        } else {
-            urlComponents.path = urlComponents.path + "/" + identifier
-        }
+        let pathSuffix = urlComponents.path.last == "/" ? identifier : "/" + identifier
+        urlComponents.path = urlComponents.path + pathSuffix
         
         guard let url = urlComponents.url else {
             throw NetworkingError.invalidUrl(withUrl: urlComponents.string ?? discoveryUrl)

--- a/VCNetworking/VCNetworking/operations/fetch/FetchDIDDocumentOperation.swift
+++ b/VCNetworking/VCNetworking/operations/fetch/FetchDIDDocumentOperation.swift
@@ -19,8 +19,7 @@ class FetchDIDDocumentOperation: InternalNetworkOperation {
          andCorrelationVector correlationVector: CorrelationHeader? = nil,
          session: URLSession = URLSession()) throws {
         
-        guard let discoveryUrl = VCSDKConfiguration.sharedInstance.discoveryUrl,
-              var urlComponents = URLComponents(string: discoveryUrl) else {
+        guard var urlComponents = URLComponents(string: VCSDKConfiguration.sharedInstance.discoveryUrl) else {
             throw NetworkingError.invalidUrl(withUrl: VCSDKConfiguration.sharedInstance.discoveryUrl)
         }
         
@@ -28,7 +27,7 @@ class FetchDIDDocumentOperation: InternalNetworkOperation {
         urlComponents.path = urlComponents.path + pathSuffix
         
         guard let url = urlComponents.url else {
-            throw NetworkingError.invalidUrl(withUrl: urlComponents.string ?? discoveryUrl)
+            throw NetworkingError.invalidUrl(withUrl: urlComponents.string ?? VCSDKConfiguration.sharedInstance.discoveryUrl)
         }
         
         self.urlRequest = URLRequest(url: url)

--- a/VCNetworking/VCNetworkingTests/operations/fetch/FetchDIDDocumentOperationTests.swift
+++ b/VCNetworking/VCNetworkingTests/operations/fetch/FetchDIDDocumentOperationTests.swift
@@ -5,6 +5,7 @@
 
 import XCTest
 import PromiseKit
+import VCEntities
 
 @testable import VCNetworking
 
@@ -28,6 +29,6 @@ class FetchDIDDocumentOperationTests: XCTestCase {
         XCTAssertTrue(fetchOperation.successHandler is SimpleSuccessHandler)
         XCTAssertTrue(fetchOperation.failureHandler is SimpleFailureHandler)
         XCTAssertTrue(fetchOperation.retryHandler is NoRetry)
-        XCTAssertEqual(fetchOperation.urlRequest.url!.absoluteString, Constants.DISCOVERY_URL + Constants.DISCOVERY_URL_PATH + expectedIdentifier)
+        XCTAssertEqual(fetchOperation.urlRequest.url!.absoluteString, VCSDKConfiguration.sharedInstance.discoveryUrl + "/" + expectedIdentifier)
     }
 }

--- a/VCServices/VCServices.xcodeproj/project.pbxproj
+++ b/VCServices/VCServices.xcodeproj/project.pbxproj
@@ -48,7 +48,6 @@
 		55BA803B2832C91B004C532A /* VCServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 550F1E3525101758009AF467 /* VCServices.framework */; };
 		55BA803D2832CDE0004C532A /* VCEntities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55BA803C2832CDE0004C532A /* VCEntities.framework */; };
 		55BF81652829B73600B61D33 /* MockIssuanceRequestValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BF81642829B73600B61D33 /* MockIssuanceRequestValidator.swift */; };
-		55CA3A7F27FB60C900615CB6 /* VCSDKConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CA3A7E27FB60C900615CB6 /* VCSDKConfiguration.swift */; };
 		55DA76ED25BE36FF009C32E0 /* MockIssuanceApiCalls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DA76EC25BE36FF009C32E0 /* MockIssuanceApiCalls.swift */; };
 		55DA76F525BE3858009C32E0 /* MockExchangeApiCalls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DA76F425BE3858009C32E0 /* MockExchangeApiCalls.swift */; };
 		55DA76FA25BE390E009C32E0 /* MockPresentationApiCalls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DA76F925BE390E009C32E0 /* MockPresentationApiCalls.swift */; };
@@ -126,7 +125,6 @@
 		55BA80392832C900004C532A /* VCNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = VCNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		55BA803C2832CDE0004C532A /* VCEntities.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = VCEntities.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		55BF81642829B73600B61D33 /* MockIssuanceRequestValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockIssuanceRequestValidator.swift; sourceTree = "<group>"; };
-		55CA3A7E27FB60C900615CB6 /* VCSDKConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = VCSDKConfiguration.swift; path = ../../VCEntities/VCEntities/util/VCSDKConfiguration.swift; sourceTree = "<group>"; };
 		55DA76EC25BE36FF009C32E0 /* MockIssuanceApiCalls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockIssuanceApiCalls.swift; sourceTree = "<group>"; };
 		55DA76F425BE3858009C32E0 /* MockExchangeApiCalls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockExchangeApiCalls.swift; sourceTree = "<group>"; };
 		55DA76F925BE390E009C32E0 /* MockPresentationApiCalls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPresentationApiCalls.swift; sourceTree = "<group>"; };
@@ -214,7 +212,6 @@
 				5531D3AF255F68280002CC0E /* PairwiseService.swift */,
 				555CE0922526AD0400C1C938 /* PresentationService.swift */,
 				5580583D25BFA2140048E6FA /* ServicesConstants.swift */,
-				55CA3A7E27FB60C900615CB6 /* VCSDKConfiguration.swift */,
 				550F1E3825101758009AF467 /* VCUseCase.h */,
 				550F1E3925101758009AF467 /* Info.plist */,
 			);
@@ -446,7 +443,6 @@
 			files = (
 				555BDB112530E6C9001E7A18 /* IdentifierDatabase.swift in Sources */,
 				555BDAEC2530AEC7001E7A18 /* VerifiableCredentialDataModel.xcdatamodeld in Sources */,
-				55CA3A7F27FB60C900615CB6 /* VCSDKConfiguration.swift in Sources */,
 				555BDB152530F024001E7A18 /* VerifiableCredentialSDK.swift in Sources */,
 				550F1E542510195A009AF467 /* IssuanceService.swift in Sources */,
 				55793BD7255C5A26007F7599 /* ExchangeService.swift in Sources */,

--- a/VCServices/VCServices/VerifiableCredentialSDK.swift
+++ b/VCServices/VCServices/VerifiableCredentialSDK.swift
@@ -14,10 +14,6 @@ public enum VCSDKInitStatus
 /// Class used to Initialize the SDK.
 public class VerifiableCredentialSDK {
     
-    private struct Constants {
-        static let DefaultDiscoveryServiceUrl = "https://discover.did.msidentity.com/v1.0/identifiers"
-    }
-    
     public static let identifierService = IdentifierService()
     
     /// Initialized the SDK.
@@ -37,8 +33,6 @@ public class VerifiableCredentialSDK {
         
         if let discoveryUrl = discoveryUrl {
             VCSDKConfiguration.sharedInstance.setDiscoveryUrl(with: discoveryUrl)
-        } else {
-            VCSDKConfiguration.sharedInstance.setDiscoveryUrl(with: Constants.DefaultDiscoveryServiceUrl)
         }
         
         /// Step 4: return success.

--- a/VCServices/VCServices/VerifiableCredentialSDK.swift
+++ b/VCServices/VCServices/VerifiableCredentialSDK.swift
@@ -20,7 +20,8 @@ public class VerifiableCredentialSDK {
     /// Returns:  Result<VCSDKInitStatus>, if successfully initialized the SDK.
     ///        Result<Error>, if there was an error, and unable to initialize SDK.
     public static func initialize(logConsumer: VCLogConsumer = DefaultVCLogConsumer(),
-                                  accessGroupIdentifier: String? = nil) -> Result<VCSDKInitStatus, Error> {
+                                  accessGroupIdentifier: String? = nil,
+                                  discoveryUrl: String? = nil) -> Result<VCSDKInitStatus, Error> {
 
         /// Step 1: Add Log to VCSDKLog shared instance.
         VCSDKLog.sharedInstance.add(consumer: logConsumer)
@@ -28,6 +29,12 @@ public class VerifiableCredentialSDK {
         /// Step 2: Set access group identifier for key chain.
         if let accessGroupIdentifier = accessGroupIdentifier {
             VCSDKConfiguration.sharedInstance.setAccessGroupIdentifier(with: accessGroupIdentifier)
+        }
+        
+        if let discoveryUrl = discoveryUrl {
+            VCSDKConfiguration.sharedInstance.setDiscoveryUrl(with: discoveryUrl)
+        } else {
+            VCSDKConfiguration.sharedInstance.setDiscoveryUrl(with: "https://discover.did.msidentity.com/v1.0/identifiers/")
         }
         
         /// Step 4: return success.

--- a/VCServices/VCServices/VerifiableCredentialSDK.swift
+++ b/VCServices/VCServices/VerifiableCredentialSDK.swift
@@ -14,6 +14,10 @@ public enum VCSDKInitStatus
 /// Class used to Initialize the SDK.
 public class VerifiableCredentialSDK {
     
+    private struct Constants {
+        static let DefaultDiscoveryServiceUrl = "https://discover.did.msidentity.com/v1.0/identifiers"
+    }
+    
     public static let identifierService = IdentifierService()
     
     /// Initialized the SDK.
@@ -34,7 +38,7 @@ public class VerifiableCredentialSDK {
         if let discoveryUrl = discoveryUrl {
             VCSDKConfiguration.sharedInstance.setDiscoveryUrl(with: discoveryUrl)
         } else {
-            VCSDKConfiguration.sharedInstance.setDiscoveryUrl(with: "https://discover.did.msidentity.com/v1.0/identifiers/")
+            VCSDKConfiguration.sharedInstance.setDiscoveryUrl(with: Constants.DefaultDiscoveryServiceUrl)
         }
         
         /// Step 4: return success.


### PR DESCRIPTION
**Problem:**
1. Update to the new discovery url. 
2. Add option to inject discovery url into SDK instead of using default one always to give developers flexibility.


**Solution:**
See Problem


**Validation:**
- All flows work E2E
- All unit test pass


**Type of change:**
- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.
