### PR TITLE
Enable validation of requests with DID documents whose public key identifiers are absolute DID URLs

### DIFF
--- a/VCEntities/VCEntities/validators/PresentationRequestValidator.swift
+++ b/VCEntities/VCEntities/validators/PresentationRequestValidator.swift
@@ -62,11 +62,11 @@ public struct PresentationRequestValidator: RequestValidating {
             throw PresentationRequestValidatorError.keyIdInTokenHeaderMalformed
         }
         
-        let publicKeyId = "#\(keyIdComponents[1])"
-        
-        /// check if key id is equal to keyId fragment in token header, and if so, validate signature. Else, continue loop.
+        /// check if key id is equal to keyId (fragment) in token header, and if so, validate signature. Else, continue loop.
+        let publicKeyIds: Set = [kid, "#\(keyIdComponents[1])"]
         for key in keys {
-            if key.id == publicKeyId,
+            if let keyId = key.id,
+               publicKeyIds.contains(keyId),
                try token.verify(using: verifier, withPublicKey: key.publicKeyJwk) {
                 return
             }

--- a/VCEntities/VCEntitiesTests/validators/PresentationRequestValidatorTests.swift
+++ b/VCEntities/VCEntitiesTests/validators/PresentationRequestValidatorTests.swift
@@ -27,6 +27,21 @@ class PresentationRequestValidatorTests: XCTestCase {
         MockTokenVerifier.wasVerifyCalled = false
     }
     
+    func testAbsoluteURLPublicKeyId() throws {
+        let keyId = "did:test#keyId"
+        let validator = PresentationRequestValidator(verifier: verifier)
+        let mockRequestClaims = createMockPresentationRequestClaims()
+        if let mockRequest = PresentationRequestToken(headers: Header(keyId: keyId),content: mockRequestClaims) {
+            let didPublicKey = IdentifierDocumentPublicKey(id: keyId,
+                                                           type: "Typetest",
+                                                           controller: "controllerTest",
+                                                           publicKeyJwk: mockPublicKey,
+                                                           purposes: ["purpose"])
+            try validator.validate(request: mockRequest, usingKeys: [didPublicKey])
+            XCTAssertTrue(MockTokenVerifier.wasVerifyCalled)
+        }
+    }
+    
     func testShouldBeValid() throws {
         let validator = PresentationRequestValidator(verifier: verifier)
         let mockRequestClaims = createMockPresentationRequestClaims()


### PR DESCRIPTION
**Problem:**
The product did not do XYZ.
Where a DID document specified an absolute DID URL as the identifier for a verification method (public key), and not a DID relative URL fragment, then that public key would not be used to verify signatures on request tokens and such signature verification could (often would) fail.

**Solution:**
Extend request token signature validation to enable it to match on verification methods which specified absolute DID URLs in addition to DID relative URL fragments as identifiers.

**Validation:**
Added an unit test

**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
