### PR TITLE
Reduce log noise: downgrade Correlation Vector logging from INFO to VERBOSE

### DIFF
--- a/VCNetworking/VCNetworking/operations/NetworkOperation.swift
+++ b/VCNetworking/VCNetworking/operations/NetworkOperation.swift
@@ -52,7 +52,7 @@ extension InternalNetworkOperation {
             let incrementedValue = cv.update()
             urlRequest.setValue(incrementedValue, forHTTPHeaderField: cv.name)
             
-            sdkLog.logInfo(message: "Correlation Vector for \(String(describing: self)): \(cv.value)")
+            sdkLog.logVerbose(message: "Correlation Vector for \(String(describing: self)): \(cv.value)")
         }
         
         return firstly {


### PR DESCRIPTION
**Problem:**
The `Correlation Vector for ...` log line fires at `INFO` level for every single network operation (`fire()`). In production Authenticator logs, these lines account for **~40% of all Verified ID log output** (832 out of 2,087 lines in a sample log file). They also include the full `String(describing: self)` of each operation object, which dumps memory addresses and internal state — not useful for diagnostics.

**Solution:**
Changed `sdkLog.logInfo(...)` → `sdkLog.logVerbose(...)` in `NetworkOperation.swift` `fire()`. The Correlation Vector is still logged but only surfaces when verbose logging is explicitly enabled. This matches the same change already merged in the WalletLibrary fork of this file.

**Validation:**
Verified against a real user log file: the 832 CV lines that were previously at INFO level would now be filtered out under default logging config, reducing log file size by ~40%.

**Type of change:**
- [x] Logging/Telemetry

**Risk:**
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

**Related PRs:**
- WalletLibrary equivalent: https://github.com/microsoft/entra-verifiedid-wallet-library-ios/pull/142
- Parent repo logging PR: https://msazure.visualstudio.com/One/_git/AD-MFA-phonefactor-phoneApp-iPhone/pullrequest/15336387